### PR TITLE
Renamed option loadingChangeCb to watchLoading

### DIFF
--- a/src/smart-apollo.js
+++ b/src/smart-apollo.js
@@ -235,8 +235,8 @@ export class SmartQuery extends SmartApollo {
       this.vm[this.options.loadingKey] += value
     }
 
-    if (this.options.loadingChangeCb) {
-      this.options.loadingChangeCb.call(this.vm, value === 1, value)
+    if (this.options.watchLoading) {
+      this.options.watchLoading.call(this.vm, value === 1, value)
     }
   }
 


### PR DESCRIPTION
Either the documentation is outdated or the current release. As I found the naming `watchLoading` way more intuitive than `loadingChangeCb` I assume it should be renamed. 