### PR TITLE
fix refetch + watchLoading when no new results are returned

### DIFF
--- a/src/smart-apollo.js
+++ b/src/smart-apollo.js
@@ -265,7 +265,7 @@ export class SmartQuery extends SmartApollo {
     variables && (this.options.variables = variables)
     if (this.observer) {
       const result = this.observer.refetch(variables).then((result) => {
-        if (result.loading === false) {
+        if (!result.loading) {
           this.loadingDone()
         }
       })

--- a/src/smart-apollo.js
+++ b/src/smart-apollo.js
@@ -264,7 +264,11 @@ export class SmartQuery extends SmartApollo {
   refetch (variables) {
     variables && (this.options.variables = variables)
     if (this.observer) {
-      const result = this.observer.refetch(variables)
+      const result = this.observer.refetch(variables).then((result) => {
+        if (result.loading === false) {
+          this.loadingDone()
+        }
+      })
       this.maySetLoading()
       return result
     }


### PR DESCRIPTION
fixes #65 
when the data hasn't changed, `nextResult` is not called and `loading` stays true. 
this resets loading in the promise returned from `refetch`.