### PR TITLE
Added info on prefetch/variables mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1153,6 +1153,8 @@ On the queries you want to prefetch on the server, add the `prefetch` option. It
  - a variables object,
  - a function that gets the context object (which can contain the URL for example) and return a variables object,
  - `true` (query's `variables` is reused).
+ 
+If you are returning a variables object in the `prefetch` option make sure it matches with the result of the `variables` option. If they do not match the query's data property will not be populated while rendering the template server-side.
 
 **Warning! You don't have access to the component instance when doing prefetching on the server. Don't use `this` in `prefetch`!**
 


### PR DESCRIPTION
Added a short description to the readme telling people that the `prefetch` and `variables` options need to match or the query result will not be populated while rendering server-side.