### PR TITLE
Don't require the key to match the query name

### DIFF
--- a/src/smart-apollo.js
+++ b/src/smart-apollo.js
@@ -232,7 +232,7 @@ export class SmartQuery extends SmartApollo {
       // No result
     } else if (typeof this.options.update === 'function') {
       this.vm[this.key] = this.options.update.call(this.vm, data)
-    } else if (data[this.key] === undefined) {
+    } else if (data[this.key] === undefined && !this.options.manual) {
       console.error(`Missing ${this.key} attribute on result`, data)
     } else if (!this.options.manual) {
       this.vm[this.key] = data[this.key]


### PR DESCRIPTION
When running query, sometimes I want to set the results to a different data value than the name of the query. This works fine when using `manual` mode, however, an error is thrown that tell me that the key doesn't exist in the results.

In manual cases, I don't think an error should be thrown.