### PR TITLE
fix TypeScript error when multiple clients are used

### DIFF
--- a/types/vue-apollo.d.ts
+++ b/types/vue-apollo.d.ts
@@ -21,7 +21,7 @@ type VueApolloOptions = {
 export class VueApollo implements PluginObject<{}> {
   [key: string]: any;
   install: PluginFunction<{}>;
-  constructor (options: { defaultClient: ApolloClient<{}>, defaultOptions?: VueApolloOptions });
+  constructor (options: { defaultClient: ApolloClient<{}>, defaultOptions?: VueApolloOptions, clients: { [key: string]:any } });
   static install(pVue: typeof Vue, options?:{} | undefined): void;
 }
 

--- a/types/vue-apollo.d.ts
+++ b/types/vue-apollo.d.ts
@@ -21,7 +21,7 @@ type VueApolloOptions = {
 export class VueApollo implements PluginObject<{}> {
   [key: string]: any;
   install: PluginFunction<{}>;
-  constructor (options: { defaultClient: ApolloClient<{}>, defaultOptions?: VueApolloOptions, clients: { [key: string]:any } });
+  constructor (options: { defaultClient: ApolloClient<{}>, defaultOptions?: VueApolloOptions, clients?: { [key: string]: ApolloClient<{}> } });
   static install(pVue: typeof Vue, options?:{} | undefined): void;
 }
 


### PR DESCRIPTION
Hello,

I am working on a project with Vue and Typescript. When I try to define multiple endpoints with below code:

```
const apolloProvider = new VueApollo({
    clients: {
      dev: endpoint1,
      t2: endpoint2,
    },
    defaultClient: endpoint1,
  })
```

There has TypeScript error that is described at below:

```
TS2345: Argument of type '{ clients: { dev: ApolloClient<NormalizedCacheObject>; t2: ApolloClient<NormalizedCacheObject>; }...' is not assignable to parameter of type '{ de
faultClient: ApolloClient<{}>; defaultOptions?: VueApolloOptions | undefined; }'.
  Object literal may only specify known properties, and 'clients' does not exist in type '{ defaultClient: ApolloClient<{}>; defaultOptions?: VueApolloOptions | undefined; }'.
```