### PR TITLE
Pass back `isLoading` to scoped-slot

### DIFF
--- a/src/components/ApolloQuery.js
+++ b/src/components/ApolloQuery.js
@@ -67,7 +67,6 @@ export default {
         networkStatus: 7,
         error: null,
       },
-      isLoading: false,
     }
   },
 
@@ -106,9 +105,6 @@ export default {
         context () { return this.context },
         skip () { return this.skip },
         manual: true,
-        watchLoading(isLoading) {
-          this.isLoading = isLoading
-        },
         result (result) {
           const { errors, loading, networkStatus } = result
           let { error } = result
@@ -160,7 +156,7 @@ export default {
     let result = this.$scopedSlots.default({
       result: this.result,
       query: this.$apollo.queries.query,
-      isLoading: this.isLoading,
+      isLoading: this.$apolloData.loading,
     })
     if (Array.isArray(result)) {
       result = result.concat(this.$slots.default)

--- a/src/components/ApolloQuery.js
+++ b/src/components/ApolloQuery.js
@@ -67,6 +67,7 @@ export default {
         networkStatus: 7,
         error: null,
       },
+      isLoading: false,
     }
   },
 
@@ -105,6 +106,9 @@ export default {
         context () { return this.context },
         skip () { return this.skip },
         manual: true,
+        watchLoading(isLoading) {
+          this.isLoading = isLoading
+        },
         result (result) {
           const { errors, loading, networkStatus } = result
           let { error } = result
@@ -156,6 +160,7 @@ export default {
     let result = this.$scopedSlots.default({
       result: this.result,
       query: this.$apollo.queries.query,
+      isLoading: this.isLoading,
     })
     if (Array.isArray(result)) {
       result = result.concat(this.$slots.default)


### PR DESCRIPTION
Right now `loading` is only set when a result is received, not when the request is sent. Using `watchLoading`, we can pass the loading state from when the request is sent.