### PR TITLE
relax getter on loading

### DIFF
--- a/src/smart-query.js
+++ b/src/smart-query.js
@@ -30,7 +30,7 @@ export default class SmartQuery extends SmartApollo {
   }
 
   get loading () {
-    return this.vm.$data.$apolloData ? this.vm.$data.$apolloData.queries[this.key].loading : this._loading
+    return this.vm.$data.$apolloData && this.vm.$data.$apolloData.queries[this.key] ? this.vm.$data.$apolloData.queries[this.key].loading : this._loading
   }
 
   set loading (value) {

--- a/src/smart-query.js
+++ b/src/smart-query.js
@@ -36,7 +36,7 @@ export default class SmartQuery extends SmartApollo {
   set loading (value) {
     if (this._loading !== value) {
       this._loading = value
-      if (this.vm.$data.$apolloData) {
+      if (this.vm.$data.$apolloData && this.vm.$data.$apolloData.queries[this.key]) {
         this.vm.$data.$apolloData.queries[this.key].loading = value
         this.vm.$data.$apolloData.loading += value ? 1 : -1
       }


### PR DESCRIPTION
Trying to solve #212 and probably some other issues where `loading of undefined` appears on Nuxtjs with child routes

@Akryum I'm not sure if this will solve the issue but I face exactly the issue where  a getter on loading is called even though the queries is empty. I have this issue on call of historyBack() from child route back to parent page.