### PR TITLE
no-cache smart queries are throwing exceptions in optimistic UI updates

### DIFF
--- a/src/smart-query.js
+++ b/src/smart-query.js
@@ -87,10 +87,12 @@ export default class SmartQuery extends SmartApollo {
       })
     }
 
-    const currentResult = this.maySetLoading()
+    if (this.options.fetchPolicy !== "no-cache") {
+      const currentResult = this.maySetLoading()
 
-    if (!currentResult.loading) {
-      this.nextResult(currentResult)
+      if (!currentResult.loading) {
+        this.nextResult(currentResult)
+      }
     }
 
     super.executeApollo(variables)


### PR DESCRIPTION
This short circuits unproductive cache work for no-cache queries that will not exist