### PR TITLE
Fix: reactiveSetter deep flag propagation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,10 +79,10 @@ const launch = function launch () {
   }
 }
 
-function defineReactiveSetter ($apollo, key, value) {
+function defineReactiveSetter ($apollo, key, value, deep) {
   if (typeof value !== 'undefined') {
     if (typeof value === 'function') {
-      $apollo.defineReactiveSetter(key, value)
+      $apollo.defineReactiveSetter(key, value, deep)
     } else {
       $apollo[key] = value
     }


### PR DESCRIPTION
Propagate deep flag from `defineReactiveSetter(...)` calls in `launch()` to `$apollo`