### PR TITLE
fix: hasOwnProperty is not a function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,7 +10,7 @@ const keywords = [
 ]
 
 function hasProperty (holder, key) {
-  return typeof holder !== 'undefined' && holder.hasOwnProperty(key)
+  return typeof holder !== 'undefined' && Object.prototype.hasOwnProperty.call(holder, key)
 }
 
 function proxyData () {


### PR DESCRIPTION
this.$options.methods may created by `Object.create`, so the object without a prototype can not use `hasOwnProperty` directly