### PR TITLE
Small typing fix

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -44,7 +44,7 @@ export interface VueApolloMutationOptions<V, R> extends MutationOptions<R> {
 export interface VueApolloSubscriptionOptions<V, R> extends SubscriptionOptions {
   query: DocumentNode;
   variables?: VariableFn<V>;
-  result?: (this: V, data: R) => void;
+  result?: (this: ApolloVueThisType<V>, data: R) => void;
 }
 
 type QueryComponentProperty<V> = ((this: ApolloVueThisType<V>) => VueApolloQueryOptions<V, any>) | VueApolloQueryOptions<V, any>


### PR DESCRIPTION
`this` type of `VueApolloSubscriptionOptions<V, R>.result` was not `ApolloVueThisType<V>`

Typescript compilation failed when `result` subscription handler used component methods and fields.