### PR TITLE
Remove default slots

### DIFF
--- a/src/components/ApolloMutation.js
+++ b/src/components/ApolloMutation.js
@@ -64,17 +64,12 @@ export default {
   },
 
   render (h) {
-    let result = this.$scopedSlots.default({
+    const result = this.$scopedSlots.default({
       mutate: this.mutate,
       loading: this.loading,
       error: this.error,
       gqlError: this.error && this.error.gqlError,
     })
-    if (Array.isArray(result)) {
-      result = result.concat(this.$slots.default)
-    } else {
-      result = [result].concat(this.$slots.default)
-    }
     return h(this.tag, result)
   },
 }

--- a/src/components/ApolloQuery.js
+++ b/src/components/ApolloQuery.js
@@ -167,17 +167,12 @@ export default {
   },
 
   render (h) {
-    let result = this.$scopedSlots.default({
+    const result = this.$scopedSlots.default({
       result: this.result,
       query: this.$apollo.queries.query,
       isLoading: this.$apolloData.loading,
       gqlError: this.result && this.result.error && this.result.error.gqlError,
     })
-    if (Array.isArray(result)) {
-      result = result.concat(this.$slots.default)
-    } else {
-      result = [result].concat(this.$slots.default)
-    }
     return h(this.tag, result)
   },
 }


### PR DESCRIPTION
Introducing default slot + slot-scope introduces the issue of order.

Example

```html
<apollo-query ...>
  <h1>My Content</h1>
  <template slot-scope="...">
    <p>My Content</p>
  </template>
</apollo-query>
```

Users would expect the `h1` to be rendered before `p` but that is not
what will happen.

The `p` will be rendered first and then the `h1` introducing issues
and behavior that people wouldn't expect.

It is better to let the composition to be another way than do this.