### PR TITLE
Fix typo on docs. Change developped to developed

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -12,7 +12,7 @@ This library integrates [apollo](https://www.apollographql.com/) in your [Vue](h
 
 ## What is Apollo?
 
-[Apollo](https://www.apollographql.com/) is a set of tools and community effort to help you use GraphQL in your apps. It's well known for its [client](https://www.apollographql.com/client) and its [server](https://www.apollographql.com/server). Apollo is developped and supported by the [Meteor Development Group](https://www.meteor.io/).
+[Apollo](https://www.apollographql.com/) is a set of tools and community effort to help you use GraphQL in your apps. It's well known for its [client](https://www.apollographql.com/client) and its [server](https://www.apollographql.com/server). Apollo is developed and supported by the [Meteor Development Group](https://www.meteor.io/).
 
 ## Links
 


### PR DESCRIPTION
This PR fixes a minor typo on the docs changing `developped` to `developed`