### PR TITLE
Fixes repeatedly throwing incorrect errors when queries hits cache immediately after an Apollo error

### DIFF
--- a/src/smart-query.js
+++ b/src/smart-query.js
@@ -70,18 +70,12 @@ export default class SmartQuery extends SmartApollo {
   }
 
   executeApollo (variables) {
-    if (this.observer) {
-      // Update variables
-      // Don't use setVariables directly or it will ignore cache
-      this.observer.setOptions(this.generateApolloOptions(variables))
-    } else {
-      if (this.sub) {
-        this.sub.unsubscribe()
-      }
-
-      // Create observer
-      this.observer = this.vm.$apollo.watchQuery(this.generateApolloOptions(variables))
+    if (this.sub) {
+      this.sub.unsubscribe()
     }
+
+    // Create observer
+    this.observer = this.vm.$apollo.watchQuery(this.generateApolloOptions(variables))
 
     this.startQuerySubscription()
 


### PR DESCRIPTION
Since v3.0.0-beta.14, query subscription is restarted after an error. This works well in most cases, but if an error occurs and subsequent queries hit the cache, the same error is thrown repeatedly instead of the correct value being fetched from the cache.

To demonstrate the behavior, let's say we have a resolver which accepts two arguments - value, and do_throw. if do_throw is false the resolver simply echoes value and if do_throw is true it throws an error with value.

Pseudocode:
```
executeApollo({"value":"1","do_throw":false}) // 1
executeApollo({"value":"12","do_throw":false}) // 12
executeApollo({"value":"123","do_throw":true}) // GraphQL error: Error: 123
executeApollo({"value":"1","do_throw":false}) // GraphQL error: Error: 123 (incorrect)
executeApollo({"value":"12","do_throw":false}) // GraphQL error: Error: 123 (incorrect)
executeApollo({"value":"4","do_throw":false}) // 4
executeApollo({"value":"1","do_throw":false}) // 1 (cached).  Queries run as expected after a cache miss
```

The problem is likely to be an upstream issue in Apollo, nevertheless, it can be resolved easily by not reusing SmartQuery.observer and creating an observer each time executeApollo() is called. (Or at least after an error has occurred.)