### PR TITLE
SmartQuery shouldn't be auto-started on server when prefetch is false

### DIFF
--- a/src/dollar-apollo.js
+++ b/src/dollar-apollo.js
@@ -106,7 +106,9 @@ export class DollarApollo {
     }
 
     const smart = this.queries[key] = new SmartQuery(this.vm, key, finalOptions, false)
-    smart.autostart()
+    if (!this.vm.$isServer || finalOptions.prefetch) {
+      smart.autostart()
+    }
 
     if (!this.vm.$isServer) {
       const subs = finalOptions.subscribeToMore

--- a/src/dollar-apollo.js
+++ b/src/dollar-apollo.js
@@ -106,7 +106,7 @@ export class DollarApollo {
     }
 
     const smart = this.queries[key] = new SmartQuery(this.vm, key, finalOptions, false)
-    if (!this.vm.$isServer || finalOptions.prefetch) {
+    if (!this.vm.$isServer || finalOptions.prefetch !== false) {
       smart.autostart()
     }
 


### PR DESCRIPTION
I found that smart queries are started on server-side even when their `prefetch` is false. This causes useless network requests and API calls.

I think this is not an intended behavior.