### PR TITLE
feat(typescript): specify "this" type for "watchLoading"

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -21,7 +21,7 @@ interface ApolloVueSubscribeToMoreOptions<V> {
   onError?: (error: Error) => void;
 }
 
-export type WatchLoading<V> = (isLoading: boolean, countModifier: number) => void
+export type WatchLoading<V> = (this: ApolloVueThisType<V>, isLoading: boolean, countModifier: number) => void
 export type ErrorHandler<V> = (this: ApolloVueThisType<V>, error: any) => void
 
 type _WatchQueryOptions = Omit<WatchQueryOptions, 'query'>; // exclude query prop because it causes type incorrectly error
@@ -38,7 +38,7 @@ interface ExtendableVueApolloQueryOptions<V, R> extends _WatchQueryOptions {
   prefetch?: (context: any) => any | boolean;
   deep?: boolean;
 }
-export interface VueApolloQueryOptions<V, R> extends ExtendableVueApolloQueryOptions<V, R> { 
+export interface VueApolloQueryOptions<V, R> extends ExtendableVueApolloQueryOptions<V, R> {
   query: ((this: ApolloVueThisType<V>) => DocumentNode) | DocumentNode;
   variables?: VariableFn<V>;
 }


### PR DESCRIPTION
Hi,

I'm currently migrating my Vue components from _basic_ syntax to _decorated_ syntax by using [vue-class-component](https://github.com/vuejs/vue-class-component) and [vue-property-decorator](https://github.com/kaorun343/vue-property-decorator), and I faced a problem.


```vue
<template>
  <div>...</div>
</template>

<script lang="ts">
import gql from 'graphql-tag';
import { Component, Vue } from 'vue-property-decorator';

@Component({
  apollo: {
    language: {
      query: gql`{ ... }`,
      variables() {
        return {
          language: this.language,
        };
      },
      error() {
        this.error = true;
      },
      watchLoading(isLoading) {
        this.loading = isLoading;
      },
    },
  },
})
export default class HelloWorld extends Vue {
  language = 'fr';
  error = false;
  loading = false;
}
</script>
```

When compiling this code, I have the following error `Property 'loading' does not exist on type 'Vue'.` (see [Travis](https://travis-ci.com/Kocal/vue-class-components-with-this-usage-in-decorators/builds/82111563#L464)). 
I first thought it was a problem of decorators or of TypeScript itself, but I had no errors for `this.language` and `this.error`. :thinking: 

Adding `this: ApolloVueThisType<V>` makes everything works :sparkles: 