### PR TITLE
chore: add Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+sudo: false
+dist: trusty
+language: node_js
+
+node_js:
+  - 8
+
+cache:
+  directories:
+    - ./node_modules
+
+before_script:
+  - npm install -g npm
+  - npm ci
+
+stages:
+  - build
+  - test
+  - docs
+
+jobs:
+  - stage: build
+    name: Build for Browser target
+    script: npm build:browser
+
+  - name: Build for ES target
+    script: npm build:es
+
+  - name: Build for UMD target
+    script: npm build:umd
+
+  - stage: test
+    name: Lint
+    script: npm test:eslint
+
+  - name: Types
+    script: npm test:types
+
+  - stage: docs
+    name: Documentation
+    script: npm docs:build


### PR DESCRIPTION
Is there a reason for vue-apollo to not having CI? 
I looked issues and pull requests, but it seems that no one have already asked this question. :disappointed: 

However, this PR add Travis integration by using [jobs and stages](https://docs.travis-ci.com/user/build-stages).

With this configuration, you will have 3 stages:
- "build", that will run 3 jobs in parallel
- "test", that will run 2 jobs in parallel
- "docs", that will run one job 

Each stages wait the previous one to start. If a stage fails (one of this job fails), then it stop the Travis build.

If you don't like this solution (job & stages are more organized, but slower), we can just run X commands in `script` hook.