### PR TITLE
Let the ApolloQuery be a renderless component if `tag` prop is undefined

### DIFF
--- a/src/components/ApolloMutation.js
+++ b/src/components/ApolloMutation.js
@@ -75,6 +75,6 @@ export default {
     } else {
       result = [result].concat(this.$slots.default)
     }
-    return h(this.tag, result)
+    return this.tag ? h(this.tag, result) : result
   },
 }

--- a/src/components/ApolloQuery.js
+++ b/src/components/ApolloQuery.js
@@ -180,6 +180,6 @@ export default {
     } else {
       result = [result].concat(this.$slots.default)
     }
-    return h(this.tag, result)
+    return this.tag ? h(this.tag, result) : result
   },
 }


### PR DESCRIPTION
Would be useful if the user could pass `undefined` as the `tag` prop in order to create a renderless component and skip the tag creation. Some times this extra level of elements could mess things up with the page layout (e.g. flexbox, etc)

Letting the user decide whether the component render the slot inside a tag (div by default) or without any extra render would be a plus.

Thanks