### PR TITLE
Add missing TypeScript declarations to $apollo

### DIFF
--- a/docs/api/dollar-apollo.md
+++ b/docs/api/dollar-apollo.md
@@ -16,6 +16,7 @@ This is the Apollo manager added to any component that uses Apollo. It can be ac
 
 ## Methods
 
+- `query`: execute a query (see [Queries](../guide/apollo/queries.md)).
 - `mutate`: execute a mutation (see [Mutations](../guide/apollo/mutations.md)).
 - `subscribe`: standard Apollo subscribe method (see [Subscriptions](../guide/apollo/subscriptions.md)).
 - `addSmartQuery`: manually add a Smart Query (not recommended).

--- a/types/test/App.ts
+++ b/types/test/App.ts
@@ -158,7 +158,7 @@ export default Vue.extend({
           pageSize,
         },
         // Mutate the previous result
-        updateQuery: (previousResult: any, result: { fetchMoreResult: any }) => {
+        updateQuery: (previousResult: any, result: { fetchMoreResult?: any }) => {
           const { fetchMoreResult } = result;
           const newTags = fetchMoreResult.tagsPage.tags;
           const hasMore = fetchMoreResult.tagsPage.hasMore;

--- a/types/vue-apollo.d.ts
+++ b/types/vue-apollo.d.ts
@@ -1,15 +1,9 @@
 import Vue, { PluginObject, PluginFunction } from 'vue';
-import { DocumentNode } from 'graphql';
-import { ApolloClient } from 'apollo-client';
-import { SubscriptionOptions, ObservableQuery } from 'apollo-client'
-import { DataProxy } from 'apollo-cache';
-import { subscribe } from 'graphql/subscription/subscribe';
+import { ApolloClient, ObservableQuery } from 'apollo-client';
 import { ApolloProvider, VueApolloComponent } from './apollo-provider'
 import {
   VueApolloQueryOptions,
-  VueApolloMutationOptions,
   VueApolloSubscriptionOptions,
-  ApolloVueThisType,
   VueApolloOptions,
   WatchLoading,
   ErrorHandler
@@ -28,15 +22,46 @@ export class VueApollo extends ApolloProvider implements PluginObject<{}>{
   static install(pVue: typeof Vue, options?:{} | undefined): void;
 }
 
-type Query<V> = (key: string, options: VueApolloQueryOptions<V, any>) => void;
-type Mutate<V, R=any> = <R=any>(params: VueApolloMutationOptions<V, R>) => Promise<R>;
-type Subscribe<R=any> = <R=any>(params: SubscriptionOptions) => ObservableQuery<R>;
-export interface ApolloProperty<V> {
-  [key: string]: Query<V> | Mutate<V> | Subscribe; // smart query
-  queries: any;
-  mutate: Mutate<V>;
-  subscribe: Subscribe;
-  addSmartQuery: Query<V>;
+interface SmartApollo<V, R=any> {
+  skip: boolean;
+  refresh(): void;
+  start(): void;
+  stop(): void;
+}
+
+export interface SmartQuery<V, R=any> extends SmartApollo<V, R> {
+  loading: boolean;
+  fetchMore: ObservableQuery<any>['fetchMore'];
+  subscribeToMore: ObservableQuery<any>['subscribeToMore'];
+  refetch: ObservableQuery<any>['refetch'];
+  setVariables: ObservableQuery<any>['setVariables'];
+  setOptions: ObservableQuery<any>['setOptions'];
+  startPolling: ObservableQuery<any>['startPolling'];
+  stopPolling: ObservableQuery<any>['stopPolling'];
+}
+
+export interface SmartSubscription<V, R=any> extends SmartApollo<V, R> {
+}
+
+export interface DollarApollo<V> {
+  vm: V;
+  queries: Record<string, SmartQuery<V, any>>;
+  subscriptions: Record<string, SmartSubscription<V, any>>;
+  client: ApolloClient<{}>;
+  readonly provider: ApolloProvider;
+  readonly loading: boolean;
+
+  // writeonly not yet implemented in TypeScript: https://github.com/Microsoft/TypeScript/issues/21759
+  /* writeonly */ skipAllQueries: boolean;
+  /* writeonly */ skipAllSubscriptions: boolean;
+  /* writeonly */ skipAll: boolean;
+
+  query: ApolloClient<{}>['query'];
+  mutate: ApolloClient<{}>['mutate'];
+  subscribe: ApolloClient<{}>['subscribe'];
+
+  addSmartQuery<R=any>(key: string, options: VueApolloQueryOptions<V, R>): SmartQuery<V, R>;
+  addSmartSubscription<R=any>(key: string, options: VueApolloSubscriptionOptions<V, R>): SmartSubscription<V, R>;
 }
 
 export function willPrefetch (component: VueApolloComponent, contextCallback?: boolean): VueApolloComponent

--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -1,5 +1,5 @@
 import Vue from "vue";
-import { VueApollo, ApolloProperty } from './vue-apollo';
+import { DollarApollo } from './vue-apollo';
 import { VueApolloComponentOption } from './options'
 
 declare module "vue/types/options" {
@@ -10,6 +10,6 @@ declare module "vue/types/options" {
 
 declare module "vue/types/vue" {
   interface Vue {
-    $apollo: ApolloProperty<any>;
+    $apollo: DollarApollo<any>;
   }
 }


### PR DESCRIPTION
This change reimplements the TypeScript bindings for `$apollo`, adding a lot of missing functionality. 

I've tried to only expose fields that are in the documented API. For that I added `$apollo.query` to the documentation as it is the method that I'm currently in need of, which spurred me to submit this PR.

Most of the methods in `SmartQuery` seemed to internally map to their equivalent method in `apollo-client`'s `ObservableQuery`, so I made their type declarations proxy to their respective methods on `ObservableQuery`. I have intentionally not done that with `$apollo.query`, `$apollo.mutate` and `$apollo.subscribe` because not only does `vue-apollo` allow them to accept a more comprehensive set of `options`, there is currently a [major issue with the type declaration of `ApolloClient.mutate`](https://github.com/apollographql/apollo-link/issues/616).

This is a breaking change:
* `$apollo.queries` is now type-checked, instead of being `any`. This is the main potential point of breakage - if people were using undocumented parts of the `SmartQuery`/`SmartSubscription` APIs, TypeScript will now catch it.
* `$apollo` no longer has an index signature. `DollarApollo` doesn't actually get extended with arbitrary extra methods, so it didn't actually make sense to have it. I don't think any code could have depended on it though - its type made it almost impossible to use.
* `$apollo.subscribe` now returns an `Observable` instead of `ObservableQuery`. This now matches reality, so if it stops any code from compiling, that code would have surely had runtime errors.