### PR TITLE
Fix new SSR API

### DIFF
--- a/ssr/index.js
+++ b/ssr/index.js
@@ -100,36 +100,37 @@ function prefetchComponent (component, vm, queries) {
 }
 
 function createFakeInstance (options, data, parent, children, context) {
-  const vm = Object.assign({}, data.attrs, data.props, {
-    $parent: parent,
-    $children: children,
-    $attrs: data.attrs,
-    $props: data.props,
-    $slots: {},
-    $scopedSlots: {},
-    $set: Globals.Vue.set,
-    $delete: Globals.Vue.delete,
-    $route: context.route,
-    $store: context.store,
-    $apollo: {
-      queries: {},
-      loading: false,
-    },
-    $apolloData: {
-      loading: false,
-    },
-    _self: {},
-    _staticTrees: [],
-    _u: resolveScopedSlots,
-  })
+  const vm = Object.assign(
+    {},
+    data.attrs,
+    data.props,
+    {
+      $parent: parent,
+      $children: children,
+      $attrs: data.attrs,
+      $props: data.props,
+      $slots: {},
+      $scopedSlots: {},
+      $set: Globals.Vue.set,
+      $delete: Globals.Vue.delete,
+      $route: context.route,
+      $store: context.store,
+      $apollo: {
+        queries: {},
+        loading: false,
+      },
+      $apolloData: {
+        loading: false,
+      },
+      _self: {},
+      _staticTrees: [],
+      _u: resolveScopedSlots,
+    }
+  )
 
   // Render and other helpers
-  for (let i = 0, len = VM_HELPERS.length; i < len; i++) {
-    vm[VM_HELPERS[i]] = noop
-  }
-  for (let i = 0, len = SSR_HELPERS.length; i < len; i++) {
-    vm[SSR_HELPERS[i]] = emptyString
-  }
+  VM_HELPERS.forEach(helper => vm[helper] = noop)
+  SSR_HELPERS.forEach(helper => vm[helper] = emptyString)
 
   // Scoped slots
   if (data.scopedSlots) {
@@ -153,7 +154,10 @@ function createFakeInstance (options, data, parent, children, context) {
   }
 
   // Methods
-  Object.assign(vm, options.methods)
+  const methods = options.methods
+  for (const key in methods) {
+    vm[key] = methods[key].bind(vm)
+  }
 
   // Computed
   const computed = options.computed
@@ -164,7 +168,7 @@ function createFakeInstance (options, data, parent, children, context) {
   // Data
   const localData = options.data
   if (typeof localData === 'function') {
-    vm._data = localData.call(vm)
+    vm._data = localData.call(vm, vm)
   } else if (typeof localData === 'object') {
     vm._data = localData
   } else {
@@ -197,7 +201,7 @@ function findRouteMatch (component, route) {
 function resolveComponent (name, options) {
   return new Promise((resolve) => {
     if (options.components) {
-      const component = resolveAsset(options, 'components', name)
+      const component = resolveAsset(options.components, name)
       if (component !== undefined) {
         resolve(component)
       }

--- a/ssr/utils.js
+++ b/ssr/utils.js
@@ -1,55 +1,53 @@
 const { noop } = require('../lib/utils')
 
-function cached (fn) {
-  var cache = Object.create(null);
-  return (function cachedFn (str) {
-    var hit = cache[str];
-    return hit || (cache[str] = fn(str))
-  })
-}
-
-const sharedPropertyDefinition = {
+const computedPropDef = {
   enumerable: true,
   configurable: true,
   get: noop,
-  set: noop
-}
-
-const camelizeRE = /-(\w)/g;
-const camelize = cached(function (str) {
-  return str.replace(camelizeRE, function (_, c) { return c ? c.toUpperCase() : ''; })
-});
-
-const capitalize = cached(function (str) {
-  return str.charAt(0).toUpperCase() + str.slice(1)
-});
-
-const hasOwnProperty = Object.prototype.hasOwnProperty;
-function hasOwn (obj, key) {
-  return hasOwnProperty.call(obj, key)
-}
-
-exports.resolveAsset = function (options, type, id) {
-  if (typeof id !== 'string') {
-    return
-  }
-  var assets = options[type];
-  if (hasOwn(assets, id)) { return assets[id] }
-  var camelizedId = camelize(id);
-  if (hasOwn(assets, camelizedId)) { return assets[camelizedId] }
-  var PascalCaseId = capitalize(camelizedId);
-  if (hasOwn(assets, PascalCaseId)) { return assets[PascalCaseId] }
-  var res = assets[id] || assets[camelizedId] || assets[PascalCaseId];
-  return res
+  set: noop,
 }
 
 exports.defineComputed = function (target, key, userDef) {
   if (typeof userDef === 'function') {
-    sharedPropertyDefinition.get = userDef
-    sharedPropertyDefinition.set = noop
+    computedPropDef.get = userDef
+    computedPropDef.set = noop
   } else {
-    sharedPropertyDefinition.get = userDef.get ? userDef.get : noop
-    sharedPropertyDefinition.set = userDef.set ? userDef.set : noop
+    computedPropDef.get = userDef.get || noop
+    computedPropDef.set = userDef.set || noop
   }
-  Object.defineProperty(target, key, sharedPropertyDefinition)
+  Object.defineProperty(target, key, computedPropDef)
+}
+
+function cached (fn) {
+  const cache = Object.create(null)
+  return function cachedFn (str) {
+    const hit = cache[str]
+    return hit || (cache[str] = fn(str))
+  }
+}
+
+const camelizeRE = /-(\w)/g
+const camelize = cached(function (str) {
+  return str.replace(camelizeRE, function (_, c) { return c ? c.toUpperCase() : '' })
+})
+
+const capitalize = cached(function (str) {
+  return str.charAt(0).toUpperCase() + str.slice(1)
+})
+
+const hasOwnProperty = Object.prototype.hasOwnProperty
+function hasOwn (obj, key) {
+  return hasOwnProperty.call(obj, key)
+}
+
+exports.resolveAsset = function (assets, id) {
+  if (typeof id !== 'string') return
+
+  if (hasOwn(assets, id)) return assets[id]
+
+  const camelCaseId = camelize(id)
+  if (hasOwn(assets, camelCaseId)) return assets[camelCaseId]
+
+  const pascalCaseId = capitalize(camelCaseId)
+  if (hasOwn(assets, pascalCaseId)) return assets[pascalCaseId]
 }

--- a/ssr/utils.js
+++ b/ssr/utils.js
@@ -1,0 +1,55 @@
+const { noop } = require('../lib/utils')
+
+function cached (fn) {
+  var cache = Object.create(null);
+  return (function cachedFn (str) {
+    var hit = cache[str];
+    return hit || (cache[str] = fn(str))
+  })
+}
+
+const sharedPropertyDefinition = {
+  enumerable: true,
+  configurable: true,
+  get: noop,
+  set: noop
+}
+
+const camelizeRE = /-(\w)/g;
+const camelize = cached(function (str) {
+  return str.replace(camelizeRE, function (_, c) { return c ? c.toUpperCase() : ''; })
+});
+
+const capitalize = cached(function (str) {
+  return str.charAt(0).toUpperCase() + str.slice(1)
+});
+
+const hasOwnProperty = Object.prototype.hasOwnProperty;
+function hasOwn (obj, key) {
+  return hasOwnProperty.call(obj, key)
+}
+
+exports.resolveAsset = function (options, type, id) {
+  if (typeof id !== 'string') {
+    return
+  }
+  var assets = options[type];
+  if (hasOwn(assets, id)) { return assets[id] }
+  var camelizedId = camelize(id);
+  if (hasOwn(assets, camelizedId)) { return assets[camelizedId] }
+  var PascalCaseId = capitalize(camelizedId);
+  if (hasOwn(assets, PascalCaseId)) { return assets[PascalCaseId] }
+  var res = assets[id] || assets[camelizedId] || assets[PascalCaseId];
+  return res
+}
+
+exports.defineComputed = function (target, key, userDef) {
+  if (typeof userDef === 'function') {
+    sharedPropertyDefinition.get = userDef
+    sharedPropertyDefinition.set = noop
+  } else {
+    sharedPropertyDefinition.get = userDef.get ? userDef.get : noop
+    sharedPropertyDefinition.set = userDef.set ? userDef.set : noop
+  }
+  Object.defineProperty(target, key, sharedPropertyDefinition)
+}


### PR DESCRIPTION
Some fixes for the new SSR implementation:

- The component resolver should allow camelCase and PascalCase names in options.components
- `no-prefetch` doesn't work
- `prefetch: true` is not documented but should be allowed for backward compatibility
- On making fake instances:
  - `localData(vm)` → `localData.call(vm)`
  - Inject computed properties, methods, `$data`, `$props`, etc.
  - Use Object.assign instead of spread properties (which may causes a syntax error in some environments)