### PR TITLE
Fix error in renderless rendering

### DIFF
--- a/src/components/ApolloMutation.js
+++ b/src/components/ApolloMutation.js
@@ -81,6 +81,6 @@ export default {
     } else {
       result = [result].concat(this.$slots.default)
     }
-    return this.tag ? h(this.tag, result) : result
+    return this.tag ? h(this.tag, result) : result[0]
   },
 }

--- a/src/components/ApolloQuery.js
+++ b/src/components/ApolloQuery.js
@@ -192,6 +192,6 @@ export default {
     } else {
       result = [result].concat(this.$slots.default)
     }
-    return this.tag ? h(this.tag, result) : result
+    return this.tag ? h(this.tag, result) : result[0]
   },
 }


### PR DESCRIPTION
this.$scopedSlots.default({}) returns an array of length one for the vNode, and the render function is expecting the vNode by itself. This fixes this bug in the current renderless functionality.