### PR TITLE
Fix apollo option in TypeScript definitions

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -4,7 +4,7 @@ import { VueApolloComponentOption } from './options'
 
 declare module "vue/types/options" {
   interface ComponentOptions<V extends Vue> {
-    apollo?: VueApolloComponentOption<V>;
+    apolloProvider?: VueApolloComponentOption<V>;
   }
 }
 


### PR DESCRIPTION
Fixes apollo option in TypeScript definitions by renaming it to apolloProvider