### PR TITLE
Adds the query() method to the Queries doc page

### DIFF
--- a/docs/guide/apollo/queries.md
+++ b/docs/guide/apollo/queries.md
@@ -396,6 +396,23 @@ created () {
 Internally, this method is called for each query entry in the component `apollo` option.
 :::
 
+## Manually executing a query
+
+You can use `this.$apollo.query()` to manually send a GraphQL query at any time in any method, and handle the result yourself: 
+
+```js
+methods: {
+  async myMethod () {
+    const { data } = await this.$apollo.query({
+      query: myQuery,
+      variables: myVariables
+    })
+    // Do what you want with data
+  }
+}
+```
+
+
 ## Advanced options
 
 There are even more options specific to vue-apollo, see the [API Reference](../../api/smart-query.md).


### PR DESCRIPTION
Hello !
For some reasons, the query() method is not presented in the Queries page of the documentation.  

This is very weird to me because it's the most simple and straightforward way of making a GraphQL query, just like you would do REST requests with Axios.
For quite some time I just thought there was no way of doing it with vue-apollo, until yesterday I randomly found the method in the API reference.

It can be super useful in some cases, for example if you need to use a query for a login, then it's very weird to do it with Smart Queries.  (I know the convention is to use mutations for login, but you don't always choose what your backend dev do)
Implementing an infinite scroll with filters can also be quite a hurdle with Smart Queries.

So I just added a section at the end of the page, but in my humble opinion it should be better placed in the page. 
For now the "Simple query" example is actually displaying a Smart Query, which feels weird to me. Smart Queries are a super powerful high level opinionated functionality, but not the most natural way of querying.  
If you agree with this, I could make other PRs :)