### PR TITLE
chore(docs): clarify defaultOptions settings

### DIFF
--- a/docs/guide/apollo/README.md
+++ b/docs/guide/apollo/README.md
@@ -103,7 +103,7 @@ const apolloProvider = new VueApollo({
 })
 ```
 
-These defaultOptions should not be confused with [Apollos `defaultOptions`](https://www.apollographql.com/docs/react/api/apollo-client.html#DefaultOptions).
+These defaultOptions should not be confused with [Apollos `defaultOptions`](https://www.apollographql.com/docs/react/api/apollo-client.html#DefaultOptions) which can beapplied to the `ApolloClient`.
 
 
 

--- a/docs/guide/apollo/README.md
+++ b/docs/guide/apollo/README.md
@@ -103,7 +103,7 @@ const apolloProvider = new VueApollo({
 })
 ```
 
-Only `$query` option is supported. [Other options](https://www.apollographql.com/docs/react/api/apollo-client.html#DefaultOptions) are not supported for now.
+These default options are not related to [Apollos `defaultOptions`](https://www.apollographql.com/docs/react/api/apollo-client.html#DefaultOptions).
 
 
 

--- a/docs/guide/apollo/README.md
+++ b/docs/guide/apollo/README.md
@@ -103,7 +103,7 @@ const apolloProvider = new VueApollo({
 })
 ```
 
-These default options are not related to [Apollos `defaultOptions`](https://www.apollographql.com/docs/react/api/apollo-client.html#DefaultOptions).
+These defaultOptions should not be confused with [Apollos `defaultOptions`](https://www.apollographql.com/docs/react/api/apollo-client.html#DefaultOptions).
 
 
 

--- a/docs/guide/apollo/README.md
+++ b/docs/guide/apollo/README.md
@@ -103,6 +103,10 @@ const apolloProvider = new VueApollo({
 })
 ```
 
+Only `$query` option is supported. [Other options](https://www.apollographql.com/docs/react/api/apollo-client.html#DefaultOptions) are not supported for now.
+
+
+
 ## Skip all
 
 You can disable all the queries for the component with `skipAllQueries`, all the subscriptions with `skipAllSubscriptions` and both with `skipAll`:

--- a/docs/guide/apollo/README.md
+++ b/docs/guide/apollo/README.md
@@ -103,7 +103,7 @@ const apolloProvider = new VueApollo({
 })
 ```
 
-These defaultOptions should not be confused with [Apollos `defaultOptions`](https://www.apollographql.com/docs/react/api/apollo-client.html#DefaultOptions) which can beapplied to the `ApolloClient`.
+These defaultOptions should not be confused with [Apollos `defaultOptions`](https://www.apollographql.com/docs/react/api/apollo-client.html#DefaultOptions) which can be applied to the `ApolloClient`.
 
 
 


### PR DESCRIPTION
Add a stentence regarding Apollos own defaultOptions.  
Some other users inclduing myself found this a bit confusing and I hope to help others. Not sure if this is wanted/needed or maybe I got something wrong.