### PR TITLE
fix(ssr): do not try to render component in in prefetchAll

### DIFF
--- a/ssr/index.js
+++ b/ssr/index.js
@@ -55,13 +55,6 @@ function walkTree (component, data, parent, children, context, queries, componen
 
     prefetchComponent(component, vm, queries)
 
-    try {
-      component.render.call(vm, vm.$createElement)
-    } catch (e) {
-      console.log(chalk.red(`Error while rendering ${component.name || component.__file}`))
-      console.log(e.stack)
-    }
-
     Promise.all(queue).then(queue => queue.filter(child => !!child).map(
       child => walkTree(child.component, child.data, vm, child.children, context, queries, components)
     )).then(() => resolve())


### PR DESCRIPTION
Hey @Akryum,

Thanks a lot for vue-apollo 🎉 

I've upgraded vue-apollo from `3.0.0-beta.19` to `3.0.0-beta.25` in my `nuxt-edge` app.

Random errors like`Cannot read property "name" of undefined` are thrown on ssr rendering 
where undefined is supposed to be the result of an apollo smart query when calling:
```js
await ApolloSSR.prefetchAll(apolloProvider, Components, ctx)
```

However the page renders just fine.

If I understand correctly `prefetchAll` is supposed to collect all queries from its subcomponents. 

But it should not try to render them once in `prefetchAll` to just be rendered again  later on in the vue-ssr render that happens after the `prefetchAll` is completed (?)

