### PR TITLE
Add query key as additional parameter to result callback, #445

### DIFF
--- a/src/smart-query.js
+++ b/src/smart-query.js
@@ -137,7 +137,7 @@ export default class SmartQuery extends SmartApollo {
     }
 
     if (hasResultCallback) {
-      this.options.result.call(this.vm, result)
+      this.options.result.call(this.vm, result, this.key)
     }
   }
 

--- a/src/smart-subscription.js
+++ b/src/smart-subscription.js
@@ -56,7 +56,7 @@ export default class SmartSubscription extends SmartApollo {
     super.nextResult(data)
 
     if (typeof this.options.result === 'function') {
-      this.options.result.call(this.vm, data)
+      this.options.result.call(this.vm, data, this.key)
     }
   }
 }


### PR DESCRIPTION
Add the query key as an additional to the result callback function, to allow the callback function to identify which query the result is coming from.  This is very useful to use allow manual SmartQuery instances to take action based on what type or client of query is incoming.  This is particularly crucial when trying to use vue-apollo to connect to multiple backends with the same schema (#216).

