### PR TITLE
Fix typo

### DIFF
--- a/docs/guide/apollo/README.md
+++ b/docs/guide/apollo/README.md
@@ -28,7 +28,7 @@ export default {
 
 ## $apollo
 
-All the components under the one which has the `apolloProvider` option have an `$apollo` helper available. This the glue between your component and Apollo and it does all the heavy lifting for you (including automatic updates and teardowns).
+All the components under the one which has the `apolloProvider` option have an `$apollo` helper available. This is the glue between your component and Apollo and it does all the heavy lifting for you (including automatic updates and teardowns).
 
 You can access the [apollo-client](https://www.apollographql.com/docs/react/) instances with `this.$apollo.provider.defaultClient` or `this.$apollo.provider.clients.<key>` (for [Multiple clients](../multiple-clients.md)) in all your vue components.
 


### PR DESCRIPTION
"This the glue" => "This is the glue"