### PR TITLE
Fix subscribeToMore being removed from the observer

### DIFF
--- a/src/smart-query.js
+++ b/src/smart-query.js
@@ -70,9 +70,16 @@ export default class SmartQuery extends SmartApollo {
   }
 
   executeApollo (variables) {
+    const variablesJson = JSON.stringify(variables)
+
     if (this.sub) {
+      if (variablesJson === this.previousVariablesJson) {
+        return
+      }
       this.sub.unsubscribe()
     }
+
+    this.previousVariablesJson = variablesJson
 
     // Create observer
     this.observer = this.vm.$apollo.watchQuery(this.generateApolloOptions(variables))


### PR DESCRIPTION
Related to #462 #456

Currently when you execute the same query more than once, every subscriptions made on this query will be removed. 

### To reproduce the bug
- attach subscribeToMore to a query
- execute the query _(the subscription is now correctly bind to the query)_
- execute the same query a second time _(the subscription is now removed from the query and the smart subscription will be ignored as the variables did not changed)_

This use case may be found when you use vue-apollo inside a vue-supply container.

I made an example of this scenario [here](https://github.com/karlito40/vue-apollo-testing). You will have to change the vue-apollo package to 3.0.0-beta.26 if you need to see the bug in action.

### Fix

My workaround is to ignore the query call when no changes has been made since the last call.
