### PR TITLE
fix(ts): Add missing declarations to $apolloProvider

### DIFF
--- a/types/vue.d.ts
+++ b/types/vue.d.ts
@@ -12,6 +12,7 @@ declare module 'vue/types/options' {
 
 declare module 'vue/types/vue' {
   interface Vue {
+    $apolloProvider?: ApolloProvider
     $apollo: DollarApollo<any>;
   }
 }


### PR DESCRIPTION
We can access the Apollo provider like `this.$apolloProvider.defaultClient.resetStore()`