### PR TITLE
docs: clarify data usage for subscriptions

### DIFF
--- a/docs/guide/apollo/subscriptions.md
+++ b/docs/guide/apollo/subscriptions.md
@@ -202,25 +202,14 @@ apollo: {
         }
       },
       // Result hook
-      result (data) {
-        console.log(data)
+      // Don't forget to destructure `data`
+      result ({ data }) {
+        console.log(data.tagAdded)
       },
     },
   },
 },
 ```
-
-If you want to work with the data you need to do this otherwise you'll get `undefined`:
-```
-...
-  // Result hook
-  result ({data}) {
-    console.log(data)
-    console.log(data.foo)
-  },
-...
-```
-
 
 You can then access the subscription with `this.$apollo.subscriptions.<name>`.
 

--- a/docs/guide/apollo/subscriptions.md
+++ b/docs/guide/apollo/subscriptions.md
@@ -210,6 +210,18 @@ apollo: {
 },
 ```
 
+If you want to work with the data you need to do this otherwise you'll get `undefined`:
+```
+...
+  // Result hook
+  result ({data}) {
+    console.log(data)
+    console.log(data.foo)
+  },
+...
+```
+
+
 You can then access the subscription with `this.$apollo.subscriptions.<name>`.
 
 :::tip


### PR DESCRIPTION
Maybe it's just me, but I was struggeling with this.

Expecting such result:
```
data: { 
  messageChanged: {
    type: "added",
    message: {…},
    __typename: "MessageChanged"
  }
}
```

According to the current docs I expected to be able to just write
```
console.log(data.messageChanged)
```
but then I get `undefined`.   
Instead I need to destruct data like `({data})` to be able to do this.  

I kinda find this consufing. I might be expectional stupid though.   
Maybe there's a better way to describe this or improve the docs.  
Happy to help out here and update this with whatever might make this clearer.