### PR TITLE
fix: ssr blocking when `skip` is true

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -91,7 +91,7 @@ function launch () {
       if (key.charAt(0) !== '$') {
         let options = apollo[key]
         const smart = this.$apollo.addSmartQuery(key, options)
-        if (options.prefetch !== false && apollo.$prefetch !== false) {
+        if (options.prefetch !== false && apollo.$prefetch !== false && !smart.skip) {
           this.$_apolloPromises.push(smart.firstRun)
         }
       }


### PR DESCRIPTION
When `skip` in query option is true or can be computed as true, the `start` method in `SmartApollo` won't be triggered, and it leads to `serverPrefetch` can't get a valid resolve function and block server side rendering.