### PR TITLE
Fix prefetch type

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -35,7 +35,7 @@ interface ExtendableVueApolloQueryOptions<V, R> extends _WatchQueryOptions {
   skip?: (this: ApolloVueThisType<V>) => boolean | boolean;
   manual?: boolean;
   subscribeToMore?: ApolloVueSubscribeToMoreOptions<V> | ApolloVueSubscribeToMoreOptions<V>[];
-  prefetch?: (context: any) => any | boolean;
+  prefetch?: ((context: any) => any) | boolean;
   deep?: boolean;
 }
 export interface VueApolloQueryOptions<V, R> extends ExtendableVueApolloQueryOptions<V, R> {


### PR DESCRIPTION
prefetch type should be `((context: any) => any) | boolean` instead of `(context: any) => (any | boolean)`, which cause a ts typecheck error when we pass in a boolean variable.