### PR TITLE
Issue 532: Check for provided truthiness.

### DIFF
--- a/src/mixin.js
+++ b/src/mixin.js
@@ -20,7 +20,7 @@ function initProvider () {
     const provided = typeof options.provide === 'function'
       ? options.provide.call(this)
       : options.provide
-    if (provided.$apolloProvider) {
+    if (provided && provided.$apolloProvider) {
       this.$apolloProvider = provided.$apolloProvider
     }
   }


### PR DESCRIPTION
This fixes an annoying issue when running specifications in mocha where apolloProvider may not be configure in the specification.