### PR TITLE
Fix `skip` and `prefetch` query options definitions

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -32,10 +32,10 @@ interface ExtendableVueApolloQueryOptions<V, R> extends _WatchQueryOptions {
   error?: ErrorHandler<V>;
   loadingKey?: string;
   watchLoading?: WatchLoading<V>;
-  skip?: (this: ApolloVueThisType<V>) => boolean | boolean;
+  skip?: ((this: ApolloVueThisType<V>) => boolean) | boolean;
   manual?: boolean;
   subscribeToMore?: ApolloVueSubscribeToMoreOptions<V> | ApolloVueSubscribeToMoreOptions<V>[];
-  prefetch?: (context: any) => any | boolean;
+  prefetch?: ((context: any) => any) | boolean;
   deep?: boolean;
 }
 export interface VueApolloQueryOptions<V, R> extends ExtendableVueApolloQueryOptions<V, R> {


### PR DESCRIPTION
`(context: any) => any | boolean` was technically `(context: any) => (any | boolean)` which ultimately resolves to `(context: any) => any`.

`skip` and `prefetch` can take a plain boolean, so this fixes that issue.