### PR TITLE
Invoke loadingDone when stopping SmartQuery

### DIFF
--- a/src/smart-query.js
+++ b/src/smart-query.js
@@ -76,6 +76,8 @@ export default class SmartQuery extends SmartApollo {
   stop () {
     super.stop()
 
+    this.loadingDone()
+
     if (this.observer) {
       this.observer.stopPolling()
       this.observer = null


### PR DESCRIPTION
Had a problem with skipped queries being stuck with `loading = true` forever.
I think that `stop()` should invoke `loadingDone()` so that stopped query isn't reporting itself as loading.