### PR TITLE
docs: updated doc according to Apollo Link doc

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -65,11 +65,11 @@ In your app, create an `ApolloClient` instance:
 
 ```js
 import { ApolloClient } from 'apollo-client'
-import { HttpLink } from 'apollo-link-http'
+import { createHttpLink } from 'apollo-link-http'
 import { InMemoryCache } from 'apollo-cache-inmemory'
 
 // HTTP connexion to the API
-const httpLink = new HttpLink({
+const httpLink = createHttpLink({
   // You should use an absolute URL here
   uri: 'http://localhost:3020/graphql',
 })


### PR DESCRIPTION
Cookies are not sent to server if following current Installation docs. `HttpLink` is no longer used, use `createHttpLink` instead ([Apollo Link docs](https://www.apollographql.com/docs/react/recipes/authentication#cookie)).