### PR TITLE
Typo in smart-subscription.md

### DIFF
--- a/docs/api/smart-subscription.md
+++ b/docs/api/smart-subscription.md
@@ -27,7 +27,7 @@ this.$apollo.subscriptions.users.skip = true
 Stops and restarts the query:
 
 ```js
-this.$apollo.subscriptions.users.restart()
+this.$apollo.subscriptions.users.refresh()
 ```
 
 ### start


### PR DESCRIPTION
Correction to code example. The real method is "refresh", not "restart".