### PR TITLE
fix: updateQuery with result hook

### DIFF
--- a/src/smart-subscription.js
+++ b/src/smart-subscription.js
@@ -34,7 +34,7 @@ export default class SmartSubscription extends SmartApollo {
         const ucb = apolloOptions.updateQuery && apolloOptions.updateQuery.bind(this.vm)
         apolloOptions.updateQuery = (...args) => {
           rcb(...args)
-          ucb && ucb(...args)
+          return ucb && ucb(...args)
         }
       }
       this.sub = this.options.linkedQuery.subscribeToMore(apolloOptions)


### PR DESCRIPTION
Hi, 

This fix allows to use `result` and `updateQuery` at same time.

My change will be more revealing than any explanation. 