### PR TITLE
I got a TypeScript Error with the written way:

### DIFF
--- a/docs/guide/apollo/subscriptions.md
+++ b/docs/guide/apollo/subscriptions.md
@@ -40,9 +40,9 @@ const wsLink = new WebSocketLink({
 const link = split(
   // split based on operation type
   ({ query }) => {
-    const { kind, operation } = getMainDefinition(query)
-    return kind === 'OperationDefinition' &&
-      operation === 'subscription'
+    const definition = getMainDefinition(query)
+    return definition.kind === 'OperationDefinition' &&
+      definition.operation === 'subscription'
   },
   wsLink,
   httpLink


### PR DESCRIPTION
Property 'operation' does not exist on type 'OperationDefinitionNode | FragmentDefinitionNode'

I changed it like it is written in the apollo docs: https://www.apollographql.com/docs/react/advanced/subscriptions
And it works.