### PR TITLE
Enhancement #453 Reactive pollInterval.

### DIFF
--- a/src/smart-apollo.js
+++ b/src/smart-apollo.js
@@ -37,12 +37,6 @@ export default class SmartApollo {
   }
 
   pollIntervalChanged (value, oldValue) {
-    //If oldValue is undefined, then apollo object is 'initialized'.
-    if(typeof oldValue === 'undefined' && value !== null) {
-      this.startPolling(value)
-      return
-    }
-
     if (value !== oldValue) {
       this.pollInterval = value
 

--- a/src/smart-apollo.js
+++ b/src/smart-apollo.js
@@ -10,6 +10,7 @@ export default class SmartApollo {
     this.initialOptions = options
     this.options = Object.assign({}, options)
     this._skip = false
+    this._pollInterval = null
     this._watchers = []
     this._destroyed = false
 
@@ -29,6 +30,28 @@ export default class SmartApollo {
     } else {
       this._skip = true
     }
+
+    if(typeof this.options.pollInterval === 'function') {
+      this._pollWatcher = this.vm.$watch(this.options.pollInterval.bind(this.vm),this.pollIntervalChanged.bind(this), {immediate:true})
+    }
+  }
+
+  pollIntervalChanged (value, oldValue) {
+    //If undefined it is initialized first time.
+    if(typeof oldValue === 'undefined' && value.pollInterval !== null) {
+      this.startPolling(value.pollInterval)
+      return
+    }
+
+    if (value.pollInterval !== oldValue.pollInterval) {
+      this.pollInterval = value.pollInterval
+
+      if(value.pollInterval == null) {
+        this.stopPolling()
+      } else {
+        this.startPolling(value.pollInterval)
+      }
+    }
   }
 
   skipChanged (value, oldValue) {
@@ -36,6 +59,14 @@ export default class SmartApollo {
       this.skip = value
     }
   }
+
+  get pollInterval() {
+    return this._pollInterval
+  }  
+
+  set pollInterval(value) {
+    this._pollInterval = value
+  }  
 
   get skip () {
     return this._skip

--- a/src/smart-apollo.js
+++ b/src/smart-apollo.js
@@ -37,19 +37,19 @@ export default class SmartApollo {
   }
 
   pollIntervalChanged (value, oldValue) {
-    //If undefined it is initialized first time.
-    if(typeof oldValue === 'undefined' && value.pollInterval !== null) {
-      this.startPolling(value.pollInterval)
+    //If oldValue is undefined, then apollo object is 'initialized'.
+    if(typeof oldValue === 'undefined' && value !== null) {
+      this.startPolling(value)
       return
     }
 
-    if (value.pollInterval !== oldValue.pollInterval) {
-      this.pollInterval = value.pollInterval
+    if (value !== oldValue) {
+      this.pollInterval = value
 
-      if(value.pollInterval == null) {
+      if(value == null) {
         this.stopPolling()
       } else {
-        this.startPolling(value.pollInterval)
+        this.startPolling(value)
       }
     }
   }


### PR DESCRIPTION
Reactive pollInterval.

Example:

````
 apollo: {
    allMessages: {
        query:gql`query { allMessages { done id information} }`,
        pollInterval() {
          return this.shouldPoll ? 300 : null
        },
    }
  }
````
![reactive pollINterval](https://user-images.githubusercontent.com/109020/57854410-7a54b300-77e8-11e9-8542-3bcfc080927e.gif)
