### PR TITLE
Typescript compilation error with latest apollo package

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -47,7 +47,7 @@ export interface VueApolloQueryOptions<V, R> extends ExtendableVueApolloQueryOpt
 export interface VueApolloMutationOptions<V, R> extends MutationOptions<R> {
   mutation: DocumentNode;
   variables?: VariableFn<V>;
-  optimisticResponse?: ((this: ApolloVueThisType<V>) => any) | any;
+  optimisticResponse?: ((this: ApolloVueThisType<V>) => R) | R;
   client?: String
 }
 

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -47,7 +47,7 @@ export interface VueApolloQueryOptions<V, R> extends ExtendableVueApolloQueryOpt
 export interface VueApolloMutationOptions<V, R> extends MutationOptions<R> {
   mutation: DocumentNode;
   variables?: VariableFn<V>;
-  optimisticResponse?: ((this: ApolloVueThisType<V>) => any) | Object;
+  optimisticResponse?: ((this: ApolloVueThisType<V>) => any) | any
 }
 
 export interface VueApolloSubscriptionOptions<V, R> extends SubscriptionOptions {


### PR DESCRIPTION
### Fixed typescript compilation error

```sh
ERROR in /Users/harmandeeppannu/Desktop/app/tailwind-ts-app/node_modules/vue-apollo/types/options.d.ts
47:18 Interface 'VueApolloMutationOptions<V, R>' incorrectly extends interface 'MutationOptions<R, OperationVariables>'.
  Types of property 'optimisticResponse' are incompatible.
    Type 'Object | ((this: ApolloVueThisType<V>) => any) | undefined' is not assignable to type 'R | ((vars: OperationVariables) => R) | undefined'.
      Type 'Object' is not assignable to type 'R | ((vars: OperationVariables) => R) | undefined'.
        The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
          Type 'Object' is not assignable to type 'R'.
            The 'Object' type is assignable to very few other types. Did you mean to use the 'any' type instead?
    45 | }
    46 |
  > 47 | export interface VueApolloMutationOptions<V, R> extends MutationOptions<R> {
       |                  ^
    48 |   mutation: DocumentNode;
    49 |   variables?: VariableFn<V>;
    50 |   optimisticResponse?: ((this: ApolloVueThisType<V>) => any) | Object;
```