### PR TITLE
Fix errors in typescript typings

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -2,8 +2,6 @@ import {
   WatchQueryOptions,
   MutationOptions,
   SubscriptionOptions,
-  SubscribeToMoreOptions,
-  ObservableQuery,
   NetworkStatus,
   ApolloQueryResult,
 } from 'apollo-client';
@@ -47,28 +45,36 @@ interface ExtendableVueApolloQueryOptions<V, R> extends _WatchQueryOptions {
   prefetch?: ((context: any) => any) | boolean;
   deep?: boolean;
 }
-export interface VueApolloQueryOptions<V, R> extends ExtendableVueApolloQueryOptions<V, R> {
+
+export interface VueApolloQueryOptions<V, R> extends WatchQueryOptions<R> {
+  client?: String;
+}
+
+export interface VueApolloWatchQueryOptions<V, R> extends ExtendableVueApolloQueryOptions<V, R> {
   query: ((this: ApolloVueThisType<V>) => DocumentNode) | DocumentNode;
   variables?: VariableFn<V>;
-  client?: String
+  client?: String;
 }
 
 export interface VueApolloMutationOptions<V, R> extends MutationOptions<R> {
   mutation: DocumentNode;
-  variables?: VariableFn<V>;
   optimisticResponse?: ((this: ApolloVueThisType<V>) => R) | R;
-  client?: String
+  client?: String;
 }
 
 export interface VueApolloSubscriptionOptions<V, R> extends SubscriptionOptions {
-  query: DocumentNode;
+  client?: String;
+}
+
+export interface VueApolloSmartSubscriptionOptions<V, R> extends SubscriptionOptions {
   variables?: VariableFn<V>;
   skip?: (this: ApolloVueThisType<V>) => boolean | boolean;
   result?: (this: V, data: FetchResult<R>) => void;
+  client?: String;
 }
 
-type QueryComponentProperty<V> = ((this: ApolloVueThisType<V>) => VueApolloQueryOptions<V, any>) | VueApolloQueryOptions<V, any>
-type SubscribeComponentProperty<V> = VueApolloSubscriptionOptions<V, any> | { [key: string]: VueApolloSubscriptionOptions<V, any> }
+type QueryComponentProperty<V> = ((this: ApolloVueThisType<V>) => VueApolloWatchQueryOptions<V, any>) | VueApolloWatchQueryOptions<V, any>
+type SubscribeComponentProperty<V> = VueApolloSmartSubscriptionOptions<V, any> | { [key: string]: VueApolloSmartSubscriptionOptions<V, any> }
 
 export type VueApolloOptions<V> = {
   $skip?: boolean,

--- a/types/vue-apollo.d.ts
+++ b/types/vue-apollo.d.ts
@@ -1,17 +1,13 @@
 import Vue, { PluginObject, PluginFunction } from 'vue';
-import { ApolloClient, ObservableQuery, ApolloQueryResult } from 'apollo-client';
-import { FetchResult } from 'apollo-link';
+import { ApolloQueryResult, ObservableQuery, SubscriptionOptions } from 'apollo-client'
 import { Observable } from 'apollo-client/util/Observable';
 import { ApolloProvider, VueApolloComponent } from './apollo-provider'
 import {
   VueApolloQueryOptions,
   VueApolloMutationOptions,
   VueApolloSubscriptionOptions,
-  VueApolloOptions,
-  WatchLoading,
-  ErrorHandler,
-} from './options';
-import { GraphQLError } from 'graphql';
+  VueApolloWatchQueryOptions
+} from './options'
 
 export class VueApollo extends ApolloProvider implements PluginObject<{}>{
   [key: string]: any;
@@ -54,10 +50,10 @@ export interface DollarApollo<V> {
   /* writeonly */ skipAll: boolean;
 
   query<R=any>(options: VueApolloQueryOptions<V, R>): Promise<ApolloQueryResult<R>>;
-  mutate<R=any>(options: VueApolloMutationOptions<V, R>): Promise<FetchResult<R>>;
-  subscribe<R=any>(options: VueApolloSubscriptionOptions<V, R>): Observable<FetchResult<R>>;
+  mutate<R=any>(options: VueApolloMutationOptions<V, R>): Promise<ApolloQueryResult<R>>;
+  subscribe<R=any>(options: SubscriptionOptions<R>): Observable<R>;
 
-  addSmartQuery<R=any>(key: string, options: VueApolloQueryOptions<V, R>): SmartQuery<V>;
+  addSmartQuery<R=any>(key: string, options: VueApolloWatchQueryOptions<V, R>): SmartQuery<V>;
   addSmartSubscription<R=any>(key: string, options: VueApolloSubscriptionOptions<V, R>): SmartSubscription<V>;
 }
 


### PR DESCRIPTION
Fixes:
1. The [following typings](https://github.com/Akryum/vue-apollo/blob/master/types/vue-apollo.d.ts#L56-L58) are for smart requests and inconsistent with `apollo-client` typings.
```
export interface DollarApollo<V> {
 // ...
  query<R=any>(options: VueApolloQueryOptions<V, R>): Promise<ApolloQueryResult<R>>;
  mutate<R=any>(options: VueApolloMutationOptions<V, R>): Promise<FetchResult<R>>;
  subscribe<R=any>(options: VueApolloSubscriptionOptions<V, R>): Observable<FetchResult<R>>;
```

2. Interface [`VueApolloSubscriptionOptions`](https://github.com/Akryum/vue-apollo/blob/master/types/options.d.ts#L63) is missing option `client`.

```
export interface VueApolloSubscriptionOptions<V, R> extends SubscriptionOptions {
  query: DocumentNode;
  variables?: VariableFn<V>;
  skip?: (this: ApolloVueThisType<V>) => boolean | boolean;
  result?: (this: V, data: FetchResult<R>) => void;
}
```

3. Argument `data` in callback [`result`](https://github.com/Akryum/vue-apollo/blob/master/types/options.d.ts#L40) has type `ApolloQueryResult<R>`, but no `R`
```
interface ExtendableVueApolloQueryOptions<V, R> extends _WatchQueryOptions {
  // ...
  result?: (this: ApolloVueThisType<V>, data: R, loader: any, netWorkStatus: NetworkStatus) => void;
}
```
