### PR TITLE
docs: clarify updateQuery prop on SubscribeToMore

### DIFF
--- a/docs/api/apollo-subscribe-to-more.md
+++ b/docs/api/apollo-subscribe-to-more.md
@@ -52,4 +52,4 @@ export default {
 
 - `document`: GraphQL document that contains the subscription or a function that receives the `gql` tag as argument and should return the transformed document.
 - `variables`: Object which will automatically update the subscription variables.
-- `updateQuery`: Function in which on can update the query result if needed.
+- `updateQuery`: Function to update the query result if needed.


### PR DESCRIPTION
The description was difficult to understand, simplified in an attempt to improve clarity.