### PR TITLE
(feat) add global prefetch apollo provider option

### DIFF
--- a/docs/api/apollo-provider.md
+++ b/docs/api/apollo-provider.md
@@ -33,6 +33,8 @@ const apolloProvider = new VueApollo({
     console.log('Global error handler')
     console.error(error)
   },
+  // Globally turn off prefetch ssr
+  prefetch: Boolean
 })
 ```
 

--- a/src/apollo-provider.js
+++ b/src/apollo-provider.js
@@ -8,6 +8,7 @@ export class ApolloProvider {
     this.defaultOptions = options.defaultOptions
     this.watchLoading = options.watchLoading
     this.errorHandler = options.errorHandler
+    this.prefetch = options.prefetch
 
     this.prefetchQueries = []
   }

--- a/src/mixin.js
+++ b/src/mixin.js
@@ -93,7 +93,7 @@ function launch () {
         const smart = this.$apollo.addSmartQuery(key, options)
         if (this.$isServer) {
           options = reapply(options, this)
-          if (options.prefetch !== false && apollo.$prefetch !== false && !smart.skip) {
+          if (apolloProvider.prefetch !== false && options.prefetch !== false && apollo.$prefetch !== false && !smart.skip) {
             this.$_apolloPromises.push(smart.firstRun)
           }
         }


### PR DESCRIPTION
This PR adds the ability to turn off prefetching globally during SSR.

Background and usage:

We have a very large graph that serves out requests.  Sometimes we will get in a situation where we need to be able to troubleshoot a slow or bad server side render.  During this we will normally add a query parameter and if that is preset, we bypass graphql.  

With the move to 3.0 and nuxt we no longer have the option to getMatchedComponents and manually run the vue-apollo queries, so to get that behavior we need a way to signal to vue-apollo to not make the requests.  