### PR TITLE
(build) Externalize apollo and graphql libraries

### DIFF
--- a/build/rollup.config.base.js
+++ b/build/rollup.config.base.js
@@ -23,4 +23,5 @@ export default {
       VERSION: JSON.stringify(config.version),
     }),
   ],
+  external: ['apollo-client', 'apollo-link', 'graphql-tag'],
 }


### PR DESCRIPTION
This PR externalizes the peer dependencies in vue-apollo in order to reduce the bundle size of vue-apollo in the default umd build.  Without this, all of those libraries are being included and compiled in a way that is not tree-shakable, which causes the bundle size to be quite large.  

Closes #660 

|Library|Before|After WithExternals|
|---|---|---|
|esm|133k|57k|
|min|52k|26k|
|umd|142k|61k|

```bash
# Current Build
drwxrwxr-x  2 talos talos   4096 Jul  5 11:50 .
drwxrwxr-x 16 talos talos   4096 Aug  7 10:26 ..
-rw-rw-r--  1 talos talos 133190 Aug  7 10:27 vue-apollo.esm.js
-rw-rw-r--  1 talos talos  52935 Aug  7 10:26 vue-apollo.min.js
-rw-rw-r--  1 talos talos 142186 Aug  7 10:27 vue-apollo.umd.js

# With externals
drwxrwxr-x  2 talos talos  4096 Jul  5 11:50 .
drwxrwxr-x 16 talos talos  4096 Aug  7 10:26 ..
-rw-rw-r--  1 talos talos 57047 Aug  7 10:28 vue-apollo.esm.js
-rw-rw-r--  1 talos talos 26922 Aug  7 10:28 vue-apollo.min.js
-rw-rw-r--  1 talos talos 61127 Aug  7 10:28 vue-apollo.umd.js
```