### PR TITLE
Fix VariableFn<V> type returns Object instead of V

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -16,7 +16,7 @@ type Diff<T extends Property, U extends Property> = ({ [P in T]: P } & { [P in U
 type Omit<T, K extends keyof T> = { [P in Diff<keyof T, K>]?: T[P] };
 
 type ApolloVueThisType<V> = V & { [key: string]: any };
-type VariableFn<V> = ((this: ApolloVueThisType<V>) => Object) | Object;
+type VariableFn<V> = ((this: ApolloVueThisType<V>) => V) | V;
 type ApolloVueUpdateQueryFn<V> = (this: ApolloVueThisType<V>, previousQueryResult: { [key: string]: any }, options: {
   error: any,
   subscriptionData: { data: any; };


### PR DESCRIPTION
The `VariableFn<V>` type incorrectly returns any `Object` type, rather than the type specified by `V`. This is a small change but has a high impact on type correctness.

This resulted in an easily preventable typing bug in our app. Here is a simplified example:

```
apollo: {
  project (): VueApolloQueryOptions<ProjectQueryVariables, ProjectQuery> {
    return {
      variables: { projectId: 5 }, // ❌ should be just id, but the type isn't checked 😢
      query: PROJECT_QUERY,
      fetchPolicy: 'network-only'
    }
  }
}
```

This means that the `variables` key of a few important things don't actually check `V` `variables` type:

- `ApolloVueSubscribeToMoreOptions<V>`
- `VueApolloQueryOptions<V, R>`
- `VueApolloMutationOptions<V, R>`
- `VueApolloSubscriptionOptions<V, R>`
