### PR TITLE
The typings for DollarApollo where missing `getClient`

### DIFF
--- a/docs/api/dollar-apollo.md
+++ b/docs/api/dollar-apollo.md
@@ -20,3 +20,4 @@ This is the Apollo manager added to any component that uses Apollo. It can be ac
 - `subscribe`: standard Apollo subscribe method (see [Subscriptions](../guide/apollo/subscriptions.md)).
 - `addSmartQuery`: manually add a Smart Query (not recommended).
 - `addSmartSubscription`: add a Smart Subscription (see [Subscriptions](../guide/apollo/subscriptions.md)).
+- `getClient`: returns the underlying ApolloClient.

--- a/types/vue-apollo.d.ts
+++ b/types/vue-apollo.d.ts
@@ -53,6 +53,7 @@ export interface DollarApollo<V> {
   /* writeonly */ skipAllSubscriptions: boolean;
   /* writeonly */ skipAll: boolean;
 
+  getClient<R=any>(): ApolloClient<R>;
   query<R=any>(options: VueApolloQueryOptions<V, R>): Promise<ApolloQueryResult<R>>;
   mutate<R=any>(options: VueApolloMutationOptions<V, R>): Promise<FetchResult<R>>;
   subscribe<R=any>(options: VueApolloSubscriptionOptions<V, R>): Observable<FetchResult<R>>;


### PR DESCRIPTION
I could not find any existing discussion on whether this field should be included or not. But the code base indicates it exists :)