### PR TITLE
ts: Remove ApolloVueThisType in favor of contextual this

### DIFF
--- a/types/apollo-provider.d.ts
+++ b/types/apollo-provider.d.ts
@@ -13,8 +13,8 @@ export class ApolloProvider<TCacheShape=any> {
     defaultClient: ApolloClient<TCacheShape>,
     defaultOptions?: VueApolloOptions<any>,
     clients?: { [key: string]: ApolloClient<TCacheShape> },
-    watchLoading?: WatchLoading<any>,
-    errorHandler?: ErrorHandler<any>
+    watchLoading?: WatchLoading,
+    errorHandler?: ErrorHandler
   })
   clients: { [key: string]: ApolloClient<TCacheShape> }
   defaultClient: ApolloClient<TCacheShape>

--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -15,60 +15,59 @@ type Property = string | number | symbol;
 type Diff<T extends Property, U extends Property> = ({ [P in T]: P } & { [P in U]: never } & { [x: string]: never })[T];
 type Omit<T, K extends keyof T> = { [P in Diff<keyof T, K>]?: T[P] };
 
-type ApolloVueThisType<V> = V & { [key: string]: any };
-type VariableFn<V> = ((this: ApolloVueThisType<V>) => Object) | Object;
-type ApolloVueUpdateQueryFn<V> = (this: ApolloVueThisType<V>, previousQueryResult: { [key: string]: any }, options: {
+type VariableFn = (() => Object) | Object;
+type ApolloVueUpdateQueryFn = (previousQueryResult: { [key: string]: any }, options: {
   error: any,
   subscriptionData: { data: any; };
   variables?: { [key: string]: any; };
 }) => Object;
 
-interface ApolloVueSubscribeToMoreOptions<V> {
+interface ApolloVueSubscribeToMoreOptions {
   document: DocumentNode;
-  variables?: VariableFn<V>;
-  updateQuery?: ApolloVueUpdateQueryFn<V>;
+  variables?: VariableFn;
+  updateQuery?: ApolloVueUpdateQueryFn;
   onError?: (error: Error) => void;
 }
 
-export type WatchLoading<V> = (this: ApolloVueThisType<V>, isLoading: boolean, countModifier: number) => void
-export type ErrorHandler<V> = (this: ApolloVueThisType<V>, error: any) => void
+export type WatchLoading = (isLoading: boolean, countModifier: number) => void
+export type ErrorHandler = (error: any) => void
 
 type _WatchQueryOptions = Omit<WatchQueryOptions, 'query'>; // exclude query prop because it causes type incorrectly error
 
-interface ExtendableVueApolloQueryOptions<V, R> extends _WatchQueryOptions {
-  update?: (this: ApolloVueThisType<V>, data: R) => any;
-  result?: (this: ApolloVueThisType<V>, data: ApolloQueryResult<R>, loader: any, netWorkStatus: NetworkStatus) => void;
-  error?: ErrorHandler<V>;
+interface ExtendableVueApolloQueryOptions<R> extends _WatchQueryOptions {
+  update?: (data: R) => any;
+  result?: (data: ApolloQueryResult<R>, loader: any, netWorkStatus: NetworkStatus) => void;
+  error?: ErrorHandler;
   loadingKey?: string;
-  watchLoading?: WatchLoading<V>;
-  skip?: ((this: ApolloVueThisType<V>) => boolean) | boolean;
+  watchLoading?: WatchLoading;
+  skip?: (() => boolean) | boolean;
   manual?: boolean;
-  subscribeToMore?: ApolloVueSubscribeToMoreOptions<V> | ApolloVueSubscribeToMoreOptions<V>[];
+  subscribeToMore?: ApolloVueSubscribeToMoreOptions | ApolloVueSubscribeToMoreOptions[];
   prefetch?: ((context: any) => any) | boolean;
   deep?: boolean;
 }
-export interface VueApolloQueryOptions<V, R> extends ExtendableVueApolloQueryOptions<V, R> {
-  query: ((this: ApolloVueThisType<V>) => DocumentNode) | DocumentNode;
-  variables?: VariableFn<V>;
+export interface VueApolloQueryOptions<R> extends ExtendableVueApolloQueryOptions<R> {
+  query: (() => DocumentNode) | DocumentNode;
+  variables?: VariableFn;
   client?: String
 }
 
-export interface VueApolloMutationOptions<V, R> extends MutationOptions<R> {
+export interface VueApolloMutationOptions<R> extends MutationOptions<R> {
   mutation: DocumentNode;
-  variables?: VariableFn<V>;
-  optimisticResponse?: ((this: ApolloVueThisType<V>) => R) | R;
+  variables?: VariableFn;
+  optimisticResponse?: (() => R) | R;
   client?: String
 }
 
-export interface VueApolloSubscriptionOptions<V, R> extends SubscriptionOptions {
+export interface VueApolloSubscriptionOptions<R> extends SubscriptionOptions {
   query: DocumentNode;
-  variables?: VariableFn<V>;
-  skip?: (this: ApolloVueThisType<V>) => boolean | boolean;
-  result?: (this: V, data: FetchResult<R>) => void;
+  variables?: VariableFn;
+  skip?: () => boolean | boolean;
+  result?: (data: FetchResult<R>) => void;
 }
 
-type QueryComponentProperty<V> = ((this: ApolloVueThisType<V>) => VueApolloQueryOptions<V, any>) | VueApolloQueryOptions<V, any>
-type SubscribeComponentProperty<V> = VueApolloSubscriptionOptions<V, any> | { [key: string]: VueApolloSubscriptionOptions<V, any> }
+type QueryComponentProperty = (() => VueApolloQueryOptions<any>) | VueApolloQueryOptions<any>
+type SubscribeComponentProperty = VueApolloSubscriptionOptions<any> | { [key: string]: VueApolloSubscriptionOptions<any> }
 
 export type VueApolloOptions<V> = {
   $skip?: boolean,
@@ -77,12 +76,12 @@ export type VueApolloOptions<V> = {
   $deep?: boolean,
   $client?: string,
   $loadingKey?: string,
-  $watchLoading?: WatchLoading<V>,
-  $error?: ErrorHandler<V>,
-  $query?: ExtendableVueApolloQueryOptions<V, any>
+  $watchLoading?: WatchLoading,
+  $error?: ErrorHandler,
+  $query?: ExtendableVueApolloQueryOptions<any>
 }
 
 export interface VueApolloComponentOption<V> extends VueApolloOptions<V> {
-  [key: string]: QueryComponentProperty<V> | SubscribeComponentProperty<V> | ExtendableVueApolloQueryOptions<V, any> | string | boolean | Function | undefined;
-  $subscribe?: SubscribeComponentProperty<V>;
+  [key: string]: QueryComponentProperty | SubscribeComponentProperty | ExtendableVueApolloQueryOptions<any> | string | boolean | Function | undefined;
+  $subscribe?: SubscribeComponentProperty;
 }

--- a/types/vue-apollo.d.ts
+++ b/types/vue-apollo.d.ts
@@ -20,14 +20,14 @@ export class VueApollo extends ApolloProvider implements PluginObject<{}>{
   static install(pVue: typeof Vue, options?:{} | undefined): void;
 }
 
-interface SmartApollo<V> {
+interface SmartApollo {
   skip: boolean;
   refresh(): void;
   start(): void;
   stop(): void;
 }
 
-export interface SmartQuery<V> extends SmartApollo<V> {
+export interface SmartQuery extends SmartApollo {
   loading: boolean;
   fetchMore: ObservableQuery<any>['fetchMore'];
   subscribeToMore: ObservableQuery<any>['subscribeToMore'];
@@ -38,14 +38,14 @@ export interface SmartQuery<V> extends SmartApollo<V> {
   stopPolling: ObservableQuery<any>['stopPolling'];
 }
 
-export interface SmartSubscription<V> extends SmartApollo<V> {
+export interface SmartSubscription extends SmartApollo {
 }
 
 export interface DollarApollo<V> {
   vm: V;
-  queries: Record<string, SmartQuery<V>>;
-  subscriptions: Record<string, SmartSubscription<V>>;
-  readonly provider: ApolloProvider;
+  queries: Record<string, SmartQuery>
+  subscriptions: Record<string, SmartSubscription>
+  readonly provider: ApolloProvider
   readonly loading: boolean;
 
   // writeonly not yet implemented in TypeScript: https://github.com/Microsoft/TypeScript/issues/21759
@@ -53,12 +53,12 @@ export interface DollarApollo<V> {
   /* writeonly */ skipAllSubscriptions: boolean;
   /* writeonly */ skipAll: boolean;
 
-  query<R=any>(options: VueApolloQueryOptions<V, R>): Promise<ApolloQueryResult<R>>;
-  mutate<R=any>(options: VueApolloMutationOptions<V, R>): Promise<FetchResult<R>>;
-  subscribe<R=any>(options: VueApolloSubscriptionOptions<V, R>): Observable<FetchResult<R>>;
+  query<R=any>(options: VueApolloQueryOptions<R>): Promise<ApolloQueryResult<R>>;
+  mutate<R=any>(options: VueApolloMutationOptions<R>): Promise<FetchResult<R>>;
+  subscribe<R=any>(options: VueApolloSubscriptionOptions<R>): Observable<FetchResult<R>>;
 
-  addSmartQuery<R=any>(key: string, options: VueApolloQueryOptions<V, R>): SmartQuery<V>;
-  addSmartSubscription<R=any>(key: string, options: VueApolloSubscriptionOptions<V, R>): SmartSubscription<V>;
+  addSmartQuery<R=any>(key: string, options: VueApolloQueryOptions<R>): SmartQuery;
+  addSmartSubscription<R=any>(key: string, options: VueApolloSubscriptionOptions<R>): SmartSubscription;
 }
 
 export function willPrefetch (component: VueApolloComponent, contextCallback?: boolean): VueApolloComponent


### PR DESCRIPTION
I think it's better to remove `ApolloVueThisType` since the current Vue [uses Contextual this](https://github.com/vuejs/vue/blob/399b53661b167e678e1c740ce788ff6699096734/types/options.d.ts#L61) (`ThisType<T>`).

Before removing ApolloVueThisType:

<img width="606" alt="Screen Shot 2019-09-03 at 13 48 43" src="https://user-images.githubusercontent.com/5351911/64144915-9345aa80-ce51-11e9-8359-28e4f57b5a17.png">

ApolloVueThisType is just the following.
```typescript
type ApolloVueThisType<V> = V & { [key: string]: any };
```

By removing ApolloVueThisType...

<img width="639" alt="Screen Shot 2019-09-03 at 13 24 52" src="https://user-images.githubusercontent.com/5351911/64144920-96409b00-ce51-11e9-938f-4d0209cf78ec.png">

we will be able to get the informations about data/props/methods/etc.