### PR TITLE
Add Webstorm integration instruction

### DIFF
--- a/docs/guide/installation.md
+++ b/docs/guide/installation.md
@@ -141,3 +141,26 @@ module.exports = {
   },
 }
 ```
+### Webstorm
+
+If you are using Webstorm, it's recommended to install the [JS GraphQL extension](https://plugins.jetbrains.com/plugin/8097-js-graphql/).
+
+Then configure it by creating a `.graphqlconfig` file in the root folder of the Vue project:
+
+```graphqlconfig
+{
+  "name": "Untitled GraphQL Schema",
+  "schemaPath": "./path/to/schema.graphql",
+  "extensions": {
+    "endpoints": {
+      "Default GraphQL Endpoint": {
+        "url": "http://url/to/the/graphql/api",
+        "headers": {
+          "user-agent": "JS GraphQL"
+        },
+        "introspect": false
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
Add instruction about integration Vue Apollo with Webstorm. Due to this change syntax highlighting in Webstorm will work correctly