### PR TITLE
Improve IE support by not using `for...of`

### DIFF
--- a/src/dollar-apollo.js
+++ b/src/dollar-apollo.js
@@ -185,9 +185,7 @@ export class DollarApollo {
   }
 
   destroy () {
-    for (const unwatch of this._watchers) {
-      unwatch()
-    }
+    this._watchers.forEach(unwatch => unwatch())
     for (let key in this.queries) {
       this.queries[key].destroy()
     }

--- a/src/smart-apollo.js
+++ b/src/smart-apollo.js
@@ -83,10 +83,10 @@ export default class SmartApollo {
   }
 
   start () {
-    this.starting = true
+    this.starting = true;
 
     // Reactive options
-    for (const prop of ['query', 'document', 'context']) {
+    ['query', 'document', 'context'].forEach(prop => {
       if (typeof this.initialOptions[prop] === 'function') {
         const queryCb = this.initialOptions[prop].bind(this.vm)
         this.options[prop] = queryCb()
@@ -102,7 +102,7 @@ export default class SmartApollo {
           deep: this.options.deep,
         }))
       }
-    }
+    })
 
     // GraphQL Variables
     if (typeof this.options.variables === 'function') {
@@ -121,9 +121,7 @@ export default class SmartApollo {
   }
 
   stop () {
-    for (const unwatch of this._watchers) {
-      unwatch()
-    }
+    this._watchers.forEach(unwatch => unwatch())
 
     if (this.sub) {
       this.sub.unsubscribe()
@@ -148,7 +146,8 @@ export default class SmartApollo {
 
   callHandlers (handlers, ...args) {
     let catched = false
-    for (const handler of handlers) {
+    for (let i = 0; i < handlers.length; i++) {
+      const handler = handlers[i]
       if (handler) {
         catched = true
         let result = handler.apply(this.vm, args)
@@ -177,9 +176,7 @@ export default class SmartApollo {
 
     if (error.graphQLErrors && error.graphQLErrors.length !== 0) {
       console.error(`GraphQL execution errors for ${this.type} '${this.key}'`)
-      for (let e of error.graphQLErrors) {
-        console.error(e)
-      }
+      error.graphQLErrors.forEach(e => console.error(e))
     } else if (error.networkError) {
       console.error(`Error sending the ${this.type} '${this.key}'`, error.networkError)
     } else {

--- a/src/smart-query.js
+++ b/src/smart-query.js
@@ -89,9 +89,7 @@ export default class SmartQuery extends SmartApollo {
       this.sub.unsubscribe()
 
       // Subscribe to more subs
-      for (const sub of this._linkedSubscriptions) {
-        sub.stop()
-      }
+      this._linkedSubscriptions.forEach(sub => sub.stop())
     }
 
     this.previousVariablesJson = variablesJson
@@ -112,9 +110,7 @@ export default class SmartQuery extends SmartApollo {
     super.executeApollo(variables)
 
     // Subscribe to more subs
-    for (const sub of this._linkedSubscriptions) {
-      sub.start()
-    }
+    this._linkedSubscriptions.forEach(sub => sub.start())
   }
 
   startQuerySubscription () {


### PR DESCRIPTION
`for...of` requires some heavy-duty polyfilling in IE 11 (Symbol and Array.prototype[Symbol.iterator] polyfills) which is unfortunate because this library otherwise works great in IE 11 with some lightweight polyfills for Object.entries() etc - any chance we could just use plain forEach/for?

I believe this would also solve #270.