### PR TITLE
Compile for...of to plain for loops

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -4,5 +4,6 @@ module.exports = {
   ],
   'plugins': [
     require('@babel/plugin-proposal-class-properties'),
+    [require('@babel/plugin-transform-for-of'), { assumeArray: true }]
   ],
 }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   "devDependencies": {
     "@babel/core": "^7.1.2",
     "@babel/plugin-proposal-class-properties": "^7.1.0",
+    "@babel/plugin-transform-for-of": "^7.4.4",
     "@babel/preset-env": "^7.1.0",
     "@types/graphql": "^14.0.1",
     "@vue/test-utils": "^1.0.0-beta.25",


### PR DESCRIPTION
Continuing from #807, compile `for...of` to plain for loops to improve support in IE 11.