### PR TITLE
fix: return partial data when variables change

### DIFF
--- a/packages/vue-apollo-composable/src/useQuery.ts
+++ b/packages/vue-apollo-composable/src/useQuery.ts
@@ -225,7 +225,7 @@ export function useQueryImpl<
     if (!isServer && (currentOptions.value?.fetchPolicy !== 'no-cache' || currentOptions.value.notifyOnNetworkStatusChange)) {
       const currentResult = query.value.getCurrentResult()
 
-      if (!currentResult.loading || currentOptions.value?.notifyOnNetworkStatusChange) {
+      if (!currentResult.loading || currentOptions.value?.returnPartialData || currentOptions.value?.notifyOnNetworkStatusChange) {
         onNextResult(currentResult)
       }
     }


### PR DESCRIPTION
@Akryum Not sure if this is the correct fix, or if it fixes all cases.

The problem is that I'm trying to use `returnPartialData` to render the page with data that is already cached from the previous query result, while the query runs. This works fine in the previous version of vue-apollo, and it works when using apollo-client directly, but this check prevents the result to update in this version.