### PR TITLE
fix: do not manually call provide

### DIFF
--- a/packages/vue-apollo/src/mixin.js
+++ b/packages/vue-apollo/src/mixin.js
@@ -14,15 +14,6 @@ function initProvider () {
       : optionValue
   } else if (options.parent && options.parent.$apolloProvider) {
     this.$apolloProvider = options.parent.$apolloProvider
-  } else if (options.provide) {
-    // TODO remove
-    // Temporary retro-compatibility
-    const provided = typeof options.provide === 'function'
-      ? options.provide.call(this)
-      : options.provide
-    if (provided && provided.$apolloProvider) {
-      this.$apolloProvider = provided.$apolloProvider
-    }
   }
 }
 


### PR DESCRIPTION
## Context

Over at GitLab, we ran into a weird quirk with VueApollo (see [relevant GitLab comment](https://gitlab.com/gitlab-org/gitlab-ui/-/merge_requests/2019#note_514671251)). 

Here's a sandbox example of the issue we ran into:

```javascript
// 1) Somewhere we use VueApollo
Vue.use(VueApollo);

// 2) Elsewhere, we initialize a top-level Vue app that **does not** give `apolloProvider`
import Root from './root.vue';

new Vue({
  el,
  render(h) {
    return h(Root, {
      props: { 
        username: 'sam'
      } 
    }; 
  },
})

// root.vue
export default {
  provide() {
    // 3) This blows up because VueApollo manually calls `provide` on `beforeCreate`.
    // Vue will usually call this **after** props and things have been set up.
    return {
      username: this.username
    };
  },
  props: {
    username: {
      type: String,
      required: true,
    },
  }, 
}
```

It looks like this manual calling of `options.provide` was to support an old VueApollo API, but since Vue 2.2.0,
Vue automatically supports `provide`. I'm guessing this isn't needed anymore :shrug: