### PR TITLE
fix(ApolloMutation): follow `mutate` contract

### DIFF
--- a/packages/vue-apollo/src/components/ApolloMutation.js
+++ b/packages/vue-apollo/src/components/ApolloMutation.js
@@ -79,6 +79,7 @@ export default {
       }).then(result => {
         this.$emit('done', result)
         this.loading = false
+        return result
       }).catch(e => {
         addGqlError(e)
         this.error = e


### PR DESCRIPTION
Exported method `mutate` was not following the contract as specified in documentation:
https://apollo.vuejs.org/api/apollo-mutation.html#mutate

It was returning `Promise<void>` rather than `Promise<FetchResult>`.