### PR TITLE
types: Single key result with __typename still counts as single key

### DIFF
--- a/packages/vue-apollo-composable/src/util/ExtractSingleKey.ts
+++ b/packages/vue-apollo-composable/src/util/ExtractSingleKey.ts
@@ -6,4 +6,4 @@ export type IsUnion<T, U = T> = U extends any ? ([T] extends [U] ? false : true)
 /**
  * Extracts an inner type if T has a single key K, otherwise it returns T.
  */
-export type ExtractSingleKey<T, K extends keyof T = keyof T> = IsUnion<K> extends true ? T : T[K]
+export type ExtractSingleKey<T, K extends keyof T = keyof T, KWithoutTypename extends K = Exclude<K, '__typename'>> = IsUnion<KWithoutTypename> extends true ? T : T[KWithoutTypename]

--- a/packages/vue-apollo-composable/tests/fixtures/graphql-example-types.ts
+++ b/packages/vue-apollo-composable/tests/fixtures/graphql-example-types.ts
@@ -71,12 +71,14 @@ export interface ExampleUpdatedSubscriptionVariables {
 }
 
 export interface SingleKeyExampleQuery {
+  __typename?: 'Root'
   example?: {
     __typename?: 'Example'
   }
 }
 
 export interface MultiKeyExampleQuery {
+  __typename?: 'Root'
   example?: {
     __typename?: 'Example'
   }


### PR DESCRIPTION
Previously, a response with a single key and a `__typename` field would not be considered as having a single key and could not be automatically extracted by `useQuery`. Complicated TypeScript definitions are not my forte, so if there's a better way of achieving this, please offer suggestions.