### PR TITLE
Remove error bubbling for mutations

### DIFF
--- a/packages/vue-apollo-composable/src/useMutation.ts
+++ b/packages/vue-apollo-composable/src/useMutation.ts
@@ -95,7 +95,6 @@ export function useMutation<
       error.value = e
       loading.value = false
       errorEvent.trigger(e)
-      throw e
     }
   }
 


### PR DESCRIPTION
Suppose you use a mutation in the `setup` method as described in the documentation. For example,
```javascript
setup() {
...
const { mutate: sendMessage, error: sendMessageError } = useMutation(gql`
  mutation sendMessage ($text: String!) {
    sendMessage (text: $text) {
      id
      text
    }
  }
`)
...
return { sendMessage }
```
and bind `sendMessage` to say a button click. If the mutation returns an error, then `sendMessageError` is correctly invoked. However, `sendMessage` also throws an error invoking Vue's global error handling, which for nuxt leads to a redirect to the error page. 
With this PR `sendMessage` no longer throws an exception, which is also the behavior for `useQuery`.

The CI build error doesn't seem to be related to my changes.