### PR TITLE
fix: Update TS definition for the query prefetch option

### DIFF
--- a/packages/vue-apollo/types/options.d.ts
+++ b/packages/vue-apollo/types/options.d.ts
@@ -63,7 +63,7 @@ export interface VueApolloQueryDefinition<Result = any, Variables = OperationVar
   loadingKey?: string
   watchLoading?: WatchLoading
   skip?: (() => boolean) | boolean
-  prefetch?: ((context: any) => any) | boolean
+  prefetch?: boolean
   client?: string
   deep?: boolean
   subscribeToMore?: VueApolloSubscribeToMoreOptions<Result, Variables> | VueApolloSubscribeToMoreOptions<Result, Variables>[]


### PR DESCRIPTION
Update the `prefetch` option to reflect that it's only ever a boolean, not also a function that returns a boolean.

I was attempting to use it as a function that returns a boolean, but it simply gets interpreted as truthy. It seems the source code only expects a boolean.