### PR TITLE
docs: Fix setup docs for Vue 3

### DIFF
--- a/packages/docs/src/guide-composable/setup.md
+++ b/packages/docs/src/guide-composable/setup.md
@@ -36,7 +36,7 @@ const app = new Vue({
 ### Vue 3
 
 ```js
-import { createApp, provide, h } from "vue";
+import { createApp, provide, h } from 'vue'
 import { DefaultApolloClient } from '@vue/apollo-composable'
 
 const app = createApp({
@@ -44,7 +44,7 @@ const app = createApp({
     provide(DefaultApolloClient, apolloClient)
   },
 
-  render: h => h(App),
+  render: () => h(App),
 })
 ```
 


### PR DESCRIPTION
`h` import from `vue` is the Vue 3 way