### PR TITLE
fix: reference error, when using useQuery

### DIFF
--- a/packages/vue-apollo-composable/src/useQuery.ts
+++ b/packages/vue-apollo-composable/src/useQuery.ts
@@ -142,6 +142,8 @@ export function useQueryImpl<
   const vm = getCurrentInstance() as CurrentInstance | null
   const isServer = vm?.$isServer ?? false
 
+  const currentOptions = ref<UseQueryOptions<TResult, TVariables>>()
+
   const documentRef = paramToRef(document)
   const variablesRef = paramToRef(variables)
   const optionsRef = paramToReactive(options)
@@ -399,7 +401,6 @@ export function useQueryImpl<
   })
 
   // Applying options
-  const currentOptions = ref<UseQueryOptions<TResult, TVariables>>()
   watch(() => isRef(optionsRef) ? optionsRef.value : optionsRef, value => {
     if (currentOptions.value && (
       currentOptions.value.throttle !== value.throttle ||


### PR DESCRIPTION
I had an reference error, when using useQuery() in alpha.13. currentOptions was referenced before being declared. (Please see my traceback.) In my pull request, I move the declaration of currentOptions to the beginning of the relevant function.

Uncaught (in promise) ReferenceError: can't access lexical declaration 'currentOptions' before initialization
    updateRestartFn useQuery.ts:358
    restart useQuery.ts:373
    useQueryImpl useQuery.ts:381
    callWithErrorHandling runtime-core.esm-bundler.js:155
    callWithAsyncErrorHandling runtime-core.esm-bundler.js:164
    job runtime-core.esm-bundler.js:2034
    doWatch runtime-core.esm-bundler.js:2081
    watch runtime-core.esm-bundler.js:1938
    useQueryImpl useQuery.ts:379
    useQuery useQuery.ts:129
    setup index.vue:84
    callWithErrorHandling runtime-core.esm-bundler.js:155
    setupStatefulComponent runtime-core.esm-bundler.js:7161
    setupComponent runtime-core.esm-bundler.js:7117
    mountComponent runtime-core.esm-bundler.js:5115
    processComponent runtime-core.esm-bundler.js:5090
    patch runtime-core.esm-bundler.js:4684
    mountChildren runtime-core.esm-bundler.js:4880
    mountElement runtime-core.esm-bundler.js:4801
    processElement runtime-core.esm-bundler.js:4773
    patch runtime-core.esm-bundler.js:4681
    mountSuspense runtime-core.esm-bundler.js:1484
    process runtime-core.esm-bundler.js:1460
    patch runtime-core.esm-bundler.js:4690
    mountChildren runtime-core.esm-bundler.js:4880
    processFragment runtime-core.esm-bundler.js:5049
    patch runtime-core.esm-bundler.js:4677
    componentEffect runtime-core.esm-bundler.js:5227
    reactiveEffect reactivity.esm-bundler.js:42
    effect reactivity.esm-bundler.js:17
    setupRenderEffect runtime-core.esm-bundler.js:5173
    mountComponent runtime-core.esm-bundler.js:5132
    processComponent runtime-core.esm-bundler.js:5090
    patch runtime-core.esm-bundler.js:4684
    componentEffect runtime-core.esm-bundler.js:5227
    reactiveEffect reactivity.esm-bundler.js:42
    effect reactivity.esm-bundler.js:17
    setupRenderEffect runtime-core.esm-bundler.js:5173
    mountComponent runtime-core.esm-bundler.js:5132
    processComponent runtime-core.esm-bundler.js:5090
    patch runtime-core.esm-bundler.js:4684
    render2 runtime-core.esm-bundler.js:5810
    mount runtime-core.esm-bundler.js:4085
    node_modules chunk-6TA7PGT5.js:8194
    viteSSR2 entry-client.js:47
    async* main.ts:16
useQuery.ts:358:9
