### PR TITLE
types: exclude null and undefined from useResult pick fn and generics

### DIFF
--- a/packages/vue-apollo-composable/src/useResult.ts
+++ b/packages/vue-apollo-composable/src/useResult.ts
@@ -60,7 +60,7 @@ export function useResult<
 > (
   result: Ref<TResult>,
   defaultValue: TDefaultValue | undefined,
-  pick: (data: TResult) => TReturnValue
+  pick: (data: Exclude<TResult, undefined>) => TReturnValue
 ): UseResultReturn<TDefaultValue | TReturnValue>
 
 export function useResult<
@@ -70,7 +70,7 @@ export function useResult<
 > (
   result: Ref<TResult>,
   defaultValue?: TDefaultValue,
-  pick?: (data: TResult) => TReturnValue,
+  pick?: (data: Exclude<TResult, undefined>) => TReturnValue,
 ): UseResultReturn<TResult | TResult[keyof TResult] | TDefaultValue | TReturnValue | undefined> {
   return computed(() => {
     const value = result.value

--- a/packages/vue-apollo-composable/src/useResult.ts
+++ b/packages/vue-apollo-composable/src/useResult.ts
@@ -17,7 +17,7 @@ export type UseResultReturn<T> = Readonly<Ref<Readonly<T>>>
  * @returns Readonly ref with `undefined` or the resolved `result`.
  */
 export function useResult<TResult, TResultKey extends keyof NonNullable<TResult> = keyof NonNullable<TResult>> (
-  result: Ref<TResult>
+  result: Ref<TResult | undefined>
 ): UseResultReturn<undefined | ExtractSingleKey<NonNullable<TResult>, TResultKey>>
 
 /**
@@ -35,7 +35,7 @@ export function useResult<TResult, TResultKey extends keyof NonNullable<TResult>
  * @returns Readonly ref with the `defaultValue` or the resolved `result`.
  */
 export function useResult<TResult, TDefaultValue, TResultKey extends keyof NonNullable<TResult> = keyof NonNullable<TResult>> (
-  result: Ref<TResult>,
+  result: Ref<TResult | undefined>,
   defaultValue: TDefaultValue
 ): UseResultReturn<TDefaultValue | ExtractSingleKey<NonNullable<TResult>, TResultKey>>
 
@@ -58,7 +58,7 @@ export function useResult<
   TDefaultValue,
   TReturnValue,
 > (
-  result: Ref<TResult>,
+  result: Ref<TResult | undefined>,
   defaultValue: TDefaultValue | undefined,
   pick: (data: Exclude<TResult, undefined>) => TReturnValue
 ): UseResultReturn<TDefaultValue | TReturnValue>
@@ -68,7 +68,8 @@ export function useResult<
   TDefaultValue,
   TReturnValue,
 > (
-  result: Ref<TResult>,
+  result: Ref<TResult | undefined>,
+
   defaultValue?: TDefaultValue,
   pick?: (data: Exclude<TResult, undefined>) => TReturnValue,
 ): UseResultReturn<TResult | TResult[keyof TResult] | TDefaultValue | TReturnValue | undefined> {

--- a/packages/vue-apollo-composable/src/useResult.ts
+++ b/packages/vue-apollo-composable/src/useResult.ts
@@ -17,7 +17,7 @@ export type UseResultReturn<T> = Readonly<Ref<Readonly<T>>>
  * @returns Readonly ref with `undefined` or the resolved `result`.
  */
 export function useResult<TResult, TResultKey extends keyof NonNullable<TResult> = keyof NonNullable<TResult>> (
-  result: Ref<TResult | undefined>
+  result: Ref<TResult | null | undefined>
 ): UseResultReturn<undefined | ExtractSingleKey<NonNullable<TResult>, TResultKey>>
 
 /**
@@ -35,7 +35,7 @@ export function useResult<TResult, TResultKey extends keyof NonNullable<TResult>
  * @returns Readonly ref with the `defaultValue` or the resolved `result`.
  */
 export function useResult<TResult, TDefaultValue, TResultKey extends keyof NonNullable<TResult> = keyof NonNullable<TResult>> (
-  result: Ref<TResult | undefined>,
+  result: Ref<TResult | null | undefined>,
   defaultValue: TDefaultValue
 ): UseResultReturn<TDefaultValue | ExtractSingleKey<NonNullable<TResult>, TResultKey>>
 
@@ -58,9 +58,9 @@ export function useResult<
   TDefaultValue,
   TReturnValue,
 > (
-  result: Ref<TResult | undefined>,
+  result: Ref<TResult | null | undefined>,
   defaultValue: TDefaultValue | undefined,
-  pick: (data: Exclude<TResult, undefined>) => TReturnValue
+  pick: (data: NonNullable<TResult>) => TReturnValue
 ): UseResultReturn<TDefaultValue | TReturnValue>
 
 export function useResult<
@@ -68,10 +68,10 @@ export function useResult<
   TDefaultValue,
   TReturnValue,
 > (
-  result: Ref<TResult | undefined>,
+  result: Ref<TResult | null | undefined>,
 
   defaultValue?: TDefaultValue,
-  pick?: (data: Exclude<TResult, undefined>) => TReturnValue,
+  pick?: (data: NonNullable<TResult>) => TReturnValue,
 ): UseResultReturn<TResult | TResult[keyof TResult] | TDefaultValue | TReturnValue | undefined> {
   return computed(() => {
     const value = result.value


### PR DESCRIPTION
I was excited to learn about https://github.com/vuejs/vue-apollo/pull/1062 which fixed the potentially undefined result.value, but ran into an issue with the types in `useResult()`. Here's the example

```ts
const pickedResult = useResult(result, [], data => data.pickableThings);
```

To get the types to work, I have to provide values for the generics which is a bit verbose, but fine:

```ts
const pickedResult = useResult<Result, PickedResult, PickedResult>(result, [], data => data.pickableThings);
```

But now that the `result.value` is correctly typed, it reveals that the type of the [`data`](https://github.com/vuejs/vue-apollo/blob/v4/packages/vue-apollo-composable/src/useResult.ts#L63) argument in the pick function needs to be fixed. The pick function [will never be called](https://github.com/vuejs/vue-apollo/blob/v4/packages/vue-apollo-composable/src/useResult.ts#L77) if its value is undefined, so data should exclude undefined from its type. This PR is just a small change to implement that.