### PR TITLE
docs: Remove leftover new in docs

### DIFF
--- a/packages/docs/src/guide-option/setup.md
+++ b/packages/docs/src/guide-option/setup.md
@@ -39,7 +39,7 @@ The provider holds the Apollo client instances that can then be used by all the 
 ```js
 import { createApolloProvider } from '@vue/apollo-option'
 
-const apolloProvider = new createApolloProvider({
+const apolloProvider = createApolloProvider({
   defaultClient: apolloClient,
 })
 ```


### PR DESCRIPTION
`createApolloProvider` shouldn't be prefixed by `new`