### PR TITLE
fix(composable): fix infinite loading in ssr

### DIFF
--- a/packages/vue-apollo-composable/src/useQuery.ts
+++ b/packages/vue-apollo-composable/src/useQuery.ts
@@ -142,7 +142,7 @@ export function useQueryImpl<
 ): UseQueryReturn<TResult, TVariables> {
   // Is on server?
   const vm = getCurrentInstance() as CurrentInstance | null
-  const isServer = vm?.$isServer ?? false
+  const isServer = vm?.$isServer ?? (vm?.proxy as CurrentInstance | null)?.$isServer ?? false
 
   const currentOptions = ref<UseQueryOptions<TResult, TVariables>>()
 

--- a/packages/vue-apollo-composable/src/useSubscription.ts
+++ b/packages/vue-apollo-composable/src/useSubscription.ts
@@ -113,7 +113,7 @@ export function useSubscription <
 ): UseSubscriptionReturn<TResult, TVariables> {
   // Is on server?
   const vm = getCurrentInstance() as CurrentInstance | null
-  const isServer = vm?.$isServer ?? false
+  const isServer = vm?.$isServer ?? (vm?.proxy as CurrentInstance | null)?.$isServer ?? false
 
   const documentRef = paramToRef(document)
   const variablesRef = paramToRef(variables)


### PR DESCRIPTION
There is no `$isServer` property in the Composition API for Vue 2. This causes an infinite load on the server.

https://github.com/vuejs/composition-api/blob/master/CHANGELOG.md#100-beta22-2020-12-19

```ts
// vm.$isServer undefined
console.log('vm.$isServer', vm.$isServer);
// vm.proxy.$isServer true
console.log('vm.proxy.$isServer', vm.proxy.$isServer);
```
Issue with reproducible error #1222, repository https://github.com/negezor/nuxt-apollo-3-slow-ssr