### PR TITLE
fixed subscriptions leak

### DIFF
--- a/packages/vue-apollo-option/src/dollar-apollo.js
+++ b/packages/vue-apollo-option/src/dollar-apollo.js
@@ -148,7 +148,13 @@ export class DollarApollo {
       smart.autostart()
 
       if (options.linkedQuery) {
-        options.linkedQuery._linkedSubscriptions.push(smart)
+        // prevent subscriptions leak on fetching query with another parameters
+        const index = options.linkedQuery._linkedSubscriptions.findIndex(x => x.key === key)
+        if (index !== -1) {
+          options.linkedQuery._linkedSubscriptions[index] = smart
+        } else {
+          options.linkedQuery._linkedSubscriptions.push(smart)
+        }
       }
 
       return smart


### PR DESCRIPTION
# Problem
For example code from URL https://apollo.vuejs.org/guide/components/subscribe-to-more.html#examples-of-updatequery on changing variables in query and subscriptions. On changing variables in query each subscriptions(in this._linkedSubscriptions) stopping and starting after query. On addSmartSubscription we push to _linkedSubscriptions current subscription. On change variables in ApolloSubscribeToMore we triggered addSmartSubscription and old subscriptions pushed in this._linkedSubscriptions.
# Resolve
deduplicate this._linkedSubscriptions on adding to _linkedSubscriptions