### PR TITLE
fix(types): add throttle and debounce options [v3]

### DIFF
--- a/types/options.d.ts
+++ b/types/options.d.ts
@@ -69,6 +69,8 @@ export interface VueApolloQueryDefinition<Instance = Vue, R = any> extends Watch
   client?: string
   deep?: boolean
   subscribeToMore?: VueApolloSubscribeToMoreOptions | (VueApolloSubscribeToMoreOptions & ThisType<Instance>)[]
+  throttle?: number
+  debounce?: number
 }
 
 /* Subscriptions */


### PR DESCRIPTION
Fixes #335 for v3 branch

These options were missing from the `VueApolloQueryDefinition` interface.