### PR TITLE
fix(types): add throttle and debounce options

### DIFF
--- a/packages/vue-apollo-option/types/options.d.ts
+++ b/packages/vue-apollo-option/types/options.d.ts
@@ -67,6 +67,8 @@ export interface VueApolloQueryDefinition<Result = any, Variables = OperationVar
   client?: string
   deep?: boolean
   subscribeToMore?: VueApolloSubscribeToMoreOptions<Result, Variables> | VueApolloSubscribeToMoreOptions<Result, Variables>[]
+  throttle?: number
+  debounce?: number
 }
 
 /* Subscriptions */


### PR DESCRIPTION
Fixes vuejs#335 for v4 branch

These options were missing from the `VueApolloQueryDefinition` interface.