### PR TITLE
chore: add repository directory for all packages.json

### DIFF
--- a/packages/vue-apollo-components/package.json
+++ b/packages/vue-apollo-components/package.json
@@ -15,7 +15,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Akryum/vue-apollo.git"
+    "url": "https://github.com/vuejs/vue-apollo.git",
+    "directory": "packages/vue-apollo-components"
   },
   "keywords": [
     "vue",
@@ -26,9 +27,9 @@
   "author": "Guillaume Chau <guillaume.b.chau@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/Akryum/vue-apollo/issues"
+    "url": "https://github.com/vuejs/vue-apollo/issues"
   },
-  "homepage": "https://github.com/Akryum/vue-apollo#readme",
+  "homepage": "https://apollo.vuejs.org/",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/vue-apollo-composable/package.json
+++ b/packages/vue-apollo-composable/package.json
@@ -4,7 +4,8 @@
   "description": "Apollo GraphQL for Vue Composition API",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Akryum/vue-apollo.git"
+    "url": "https://github.com/vuejs/vue-apollo.git",
+    "directory": "packages/vue-apollo-composable"
   },
   "keywords": [
     "vue",
@@ -15,9 +16,9 @@
   "author": "Guillaume Chau <guillaume.b.chau@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/Akryum/vue-apollo/issues"
+    "url": "https://github.com/vuejs/vue-apollo/issues"
   },
-  "homepage": "https://github.com/Akryum/vue-apollo#readme",
+  "homepage": "https://apollo.vuejs.org/",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/vue-apollo-option/package.json
+++ b/packages/vue-apollo-option/package.json
@@ -19,7 +19,8 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Akryum/vue-apollo.git"
+    "url": "https://github.com/vuejs/vue-apollo.git",
+    "directory": "packages/vue-apollo-option"
   },
   "keywords": [
     "vue",
@@ -31,9 +32,9 @@
   "author": "Guillaume Chau <guillaume.b.chau@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/Akryum/vue-apollo/issues"
+    "url": "https://github.com/vuejs/vue-apollo/issues"
   },
-  "homepage": "https://github.com/Akryum/vue-apollo#readme",
+  "homepage": "https://apollo.vuejs.org/",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/vue-apollo-ssr/package.json
+++ b/packages/vue-apollo-ssr/package.json
@@ -4,7 +4,8 @@
   "description": "Apollo GraphQL for Vue - Server Side Rendering utilities",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Akryum/vue-apollo.git"
+    "url": "https://github.com/vuejs/vue-apollo.git",
+    "directory": "packages/vue-apollo-ssr"
   },
   "keywords": [
     "vue",
@@ -15,9 +16,9 @@
   "author": "Guillaume Chau <guillaume.b.chau@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/Akryum/vue-apollo/issues"
+    "url": "https://github.com/vuejs/vue-apollo/issues"
   },
-  "homepage": "https://github.com/Akryum/vue-apollo#readme",
+  "homepage": "https://apollo.vuejs.org/",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/vue-apollo-util/package.json
+++ b/packages/vue-apollo-util/package.json
@@ -4,7 +4,8 @@
   "description": "Apollo GraphQL for Vue - Utilities",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Akryum/vue-apollo.git"
+    "url": "https://github.com/vuejs/vue-apollo.git",
+    "directory": "packages/vue-apollo-util"
   },
   "keywords": [
     "vue",
@@ -15,9 +16,9 @@
   "author": "Guillaume Chau <guillaume.b.chau@gmail.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/Akryum/vue-apollo/issues"
+    "url": "https://github.com/vuejs/vue-apollo/issues"
   },
-  "homepage": "https://github.com/Akryum/vue-apollo#readme",
+  "homepage": "https://apollo.vuejs.org/",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
> If the package.json for your package is not in the root directory (for example if it is part of a monorepo), you can specify the directory in which it lives:
> ```json
> "repository": {
>   "type" : "git",
>   "url" : "https://github.com/facebook/react.git",
>   "directory": "packages/react-dom"
> }
> ```
> — https://docs.npmjs.com/cli/v6/configuring-npm/package-json#repository

I use a lot https://njt.vercel.app/ to jump to different packages information,
and with this PR we can know exactly what package in what folder lives

Made the changes with a script to make it easier 🙂

https://gist.github.com/iamandrewluca/5cc85b56a595056f0099d04ed6dd8a79