### PR TITLE
fix: useMutation outside setup

### DIFF
--- a/packages/vue-apollo-composable/src/useMutation.ts
+++ b/packages/vue-apollo-composable/src/useMutation.ts
@@ -106,7 +106,7 @@ export function useMutation<
     return null
   }
 
-  onBeforeUnmount(() => {
+  vm && onBeforeUnmount(() => {
     loading.value = false
   })
 


### PR DESCRIPTION
I was trying to run a mutation outside of setup, and was getting a warning saying `onBeforeUnmount is called when there is no active component instance to be associated with`

It looks like we're already doing something similar inside of useQuery.ts, just added a similar check to see if vm is set before calling the lifecycle method