### PR TITLE
fix: destruction of $apollo in vue-apollo-option

### DIFF
--- a/packages/vue-apollo-option/src/mixin.js
+++ b/packages/vue-apollo-option/src/mixin.js
@@ -103,9 +103,9 @@ function defineReactiveSetter ($apollo, key, value, deep) {
 }
 
 function destroy () {
-  if (this.$_apollo) {
-    this.$_apollo.destroy()
-    this.$_apollo = null
+  if (this.$apollo) {
+    this.$apollo.destroy()
+    this.$apollo = null
   }
 }
 


### PR DESCRIPTION
The $apollo instance is not correctly destroyed on component destruction due to a typo.