### PR TITLE
chore(deps): upgrade vue-demi to 0.12.1

### DIFF
--- a/packages/test-e2e-composable-vue3/package.json
+++ b/packages/test-e2e-composable-vue3/package.json
@@ -21,7 +21,7 @@
     "graphql": "^15.3.0",
     "shortid": "^2.2.15",
     "vue": "^3.0.0",
-    "vue-demi": "^0.4.0",
+    "vue-demi": "^0.12.1",
     "vue-router": "^4.0.0-beta.13"
   },
   "devDependencies": {

--- a/packages/vue-apollo-composable/package.json
+++ b/packages/vue-apollo-composable/package.json
@@ -39,7 +39,7 @@
   "dependencies": {
     "throttle-debounce": "^3.0.1",
     "ts-essentials": "^8.1.0",
-    "vue-demi": "^0.11.4"
+    "vue-demi": "^0.12.1"
   },
   "peerDependencies": {
     "@apollo/client": "^3.4.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15573,15 +15573,10 @@ vue-class-component@^7.1.0:
   resolved "https://registry.yarnpkg.com/vue-class-component/-/vue-class-component-7.2.6.tgz#8471e037b8e4762f5a464686e19e5afc708502e4"
   integrity sha512-+eaQXVrAm/LldalI272PpDe3+i4mPis0ORiMYxF6Ae4hyuCh15W8Idet7wPUEs4N4YptgFHGys4UrgNQOMyO6w==
 
-vue-demi@^0.11.4:
-  version "0.11.4"
-  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.11.4.tgz#6101992fe4724cf5634018a16e953f3052e94e2a"
-  integrity sha512-/3xFwzSykLW2HiiLie43a+FFgNOcokbBJ+fzvFXd0r2T8MYohqvphUyDQ8lbAwzQ3Dlcrb1c9ykifGkhSIAk6A==
-
-vue-demi@^0.4.0:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.4.5.tgz#ea422a4468cb6321a746826a368a770607f87791"
-  integrity sha512-51xf1B6hV2PfjnzYHO/yUForFCRQ49KS8ngQb5T6l1HDEmfghTFtsxtRa5tbx4eqQsH76ll/0gIxuf1gei0ubw==
+vue-demi@^0.12.1:
+  version "0.12.1"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.12.1.tgz#f7e18efbecffd11ab069d1472d7a06e319b4174c"
+  integrity sha512-QL3ny+wX8c6Xm1/EZylbgzdoDolye+VpCXRhI2hug9dJTP3OUJ3lmiKN3CsVV3mOJKwFi0nsstbgob0vG7aoIw==
 
 vue-eslint-parser@^7.0.0, vue-eslint-parser@^7.10.0:
   version "7.11.0"


### PR DESCRIPTION
Composition API changed ESM file from `esm.js` to `.mjs`
https://github.com/vueuse/vue-demi/releases/tag/v0.12.1
