### PR TITLE
fix: avoid onServerPrefetch warning

### DIFF
--- a/packages/vue-apollo-composable/src/useQuery.ts
+++ b/packages/vue-apollo-composable/src/useQuery.ts
@@ -171,7 +171,7 @@ export function useQueryImpl<
   // SSR
   let firstResolve: (() => void) | undefined
   let firstReject: ((apolloError: ApolloError) => void) | undefined
-  onServerPrefetch?.(() => {
+  vm && onServerPrefetch?.(() => {
     if (!isEnabled.value || (isServer && currentOptions.value?.prefetch === false)) return
 
     return new Promise<void>((resolve, reject) => {


### PR DESCRIPTION
Avoid the following Vue warning, when queries are used before the Vue mount:

`onServerPrefetch is called when there is no active component instance to be associated with. Lifecycle injection APIs can only be used during execution of setup(). If you are using async setup(), make sure to register lifecycle hooks before the first await statement.`

We use some queries before the mount of the main app (outside of a component setup), so that we have already some "general" information at the very beginning (e.g. the authentication information) during the app initialization.