### PR TITLE
docs: fix fetch policy for useMutation

### DIFF
--- a/packages/docs/src/api/use-mutation.md
+++ b/packages/docs/src/api/use-mutation.md
@@ -20,9 +20,6 @@
     - `ignore`
 
   - `fetchPolicy`: Specifies the `FetchPolicy` to be used for this mutation.
-    - `cache-first` (default): return result from cache. Only fetch from network if cached result is not available.
-    - `cache-and-network`: return result from cache first (if it exists), then return network result once it's available.
-    - `cache-only`: return result from cache if available, fail otherwise.
     - `network-only`: return result from network, fail if network call doesn't succeed, save to cache.
     - `no-cache`: return result from network, fail if network call doesn't succeed, don't save to cache.
 


### PR DESCRIPTION
As per docs from apollo client, mutations do not support fetch policies besides `network-only` and `no-cache` but the current vue-apollo docs lists all of them.

![image](https://user-images.githubusercontent.com/6721822/143074586-78cc65a5-2a5b-45c6-a9e0-d7b49612609a.png)

Additional note: The TS types also reflect this from `@apollo/client`. 
![image](https://user-images.githubusercontent.com/6721822/143074920-0b712e2b-2988-4295-8bec-bc4273fbac9a.png)
