### PR TITLE
Always deep freeze results from apollo

### DIFF
--- a/packages/vue-apollo/lib/utils.js
+++ b/packages/vue-apollo/lib/utils.js
@@ -36,5 +36,30 @@ exports.addGqlError = function (error) {
   }
 }
 
+exports.deepFreeze = function deepFreeze (value) {
+  const valid = (val) => (val) && typeof val === 'object'
+  const work = new Set([value])
+
+  work.forEach(obj => {
+    if (!valid(obj)) {
+      return
+    }
+
+    if (!Object.isFrozen(obj)) {
+      try {
+        Object.freeze(obj)
+      } catch (e) {
+        return
+      }
+    }
+
+    Object.getOwnPropertyNames(obj).forEach(name => {
+      if (valid(obj[name])) {
+        work.add(obj[name])
+      }
+    })
+  })
+}
+
 // eslint-disable-next-line @typescript-eslint/no-empty-function
 exports.noop = () => {}

--- a/packages/vue-apollo/src/smart-apollo.js
+++ b/packages/vue-apollo/src/smart-apollo.js
@@ -1,4 +1,4 @@
-import { throttle, debounce, omit, addGqlError } from '../lib/utils'
+import { throttle, debounce, omit, addGqlError, deepFreeze } from '../lib/utils'
 
 const skippAllKeys = {
   query: '_skipAllQueries',
@@ -160,6 +160,8 @@ export default class SmartApollo {
   nextResult (result) {
     const { error } = result
     if (error) addGqlError(error)
+
+    deepFreeze(result)
   }
 
   callHandlers (handlers, ...args) {


### PR DESCRIPTION
I noticed the production app was using twice as much memory as the development builds.
It seems this is the reason. In development builds apollo deep freezes the results. 
Reactivity on the apollo results does not make sense since apollo notifies us on changes.

This fixed it for me but I'm not sure if there are any browser compat issues with using Set.
Something similar should probably be done for v4.


