### PR TITLE
fix: added default client `errorPolicy` check to `onError` hook

### DIFF
--- a/packages/vue-apollo-composable/src/useQuery.ts
+++ b/packages/vue-apollo-composable/src/useQuery.ts
@@ -283,8 +283,10 @@ export function useQueryImpl<
   function onError (queryError: unknown) {
     // any error should already be an ApolloError, but we make sure
     const apolloError = toApolloError(queryError)
+    const client = resolveClient(currentOptions.value?.clientId)
+    const errorPolicy = currentOptions.value?.errorPolicy || client.defaultOptions?.watchQuery?.errorPolicy
 
-    if (currentOptions.value?.errorPolicy !== 'none') {
+    if (errorPolicy && errorPolicy !== 'none') {
       processNextResult((query.value as ObservableQuery<TResult, TVariables>).getCurrentResult())
     }
     processError(apolloError)


### PR DESCRIPTION
As described in https://github.com/vuejs/apollo/issues/1316, currently `onResult` hook is triggered on query error if no `errorPolicy` is specified in query options. Setting `errorPolicy` to `none` in the Apollo Client `defaultOptions` doesn't have any effect - even if we set it to `none` explicitly, we still can see `onResult` hook triggered (here is a [sandbox](https://codesandbox.io/s/vue-3-apollo-3-composables-forked-xrmhl?file=/src/main.js) which reproduces this bug)

This PR attempts to fix two issues:
1. If `errorPolicy` is `undefined` for both client and query options, we default it to `none` to be consistent with Apollo Client defaults.
2. If `errorPolicy` is not defined in query options, we also check client `defaultOptions` for it.

Close https://github.com/vuejs/apollo/issues/1316

