### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/.test-todo/test-ssr-composition/src/entry-server.js
+++ b/.test-todo/test-ssr-composition/src/entry-server.js
@@ -5,7 +5,7 @@ import { createApp } from './main'
 const prepareUrlForRouting = url => {
   const { BASE_URL } = process.env
   return url.startsWith(BASE_URL.replace(/\/$/, ''))
-    ? url.substr(BASE_URL.length)
+    ? url.slice(BASE_URL.length)
     : url
 }
 

--- a/.test-todo/test-ssr-composition/src/vue-apollo.js
+++ b/.test-todo/test-ssr-composition/src/vue-apollo.js
@@ -7,7 +7,7 @@ const AUTH_TOKEN = 'apollo-token'
 // Http endpoint
 const httpEndpoint = process.env.VUE_APP_GRAPHQL_HTTP || 'http://localhost:4042/graphql'
 // Files URL root
-export const filesRoot = process.env.VUE_APP_FILES_ROOT || httpEndpoint.substr(0, httpEndpoint.indexOf('/graphql'))
+export const filesRoot = process.env.VUE_APP_FILES_ROOT || httpEndpoint.substring(0, httpEndpoint.indexOf('/graphql'))
 
 Vue.prototype.$filesRoot = filesRoot
 

--- a/.test-todo/test-ssr/src/entry-server.js
+++ b/.test-todo/test-ssr/src/entry-server.js
@@ -5,7 +5,7 @@ import { createApp } from './main'
 const prepareUrlForRouting = url => {
   const { BASE_URL } = process.env
   return url.startsWith(BASE_URL.replace(/\/$/, ''))
-    ? url.substr(BASE_URL.length)
+    ? url.slice(BASE_URL.length)
     : url
 }
 

--- a/.test-todo/test-ssr/src/vue-apollo.js
+++ b/.test-todo/test-ssr/src/vue-apollo.js
@@ -13,7 +13,7 @@ const AUTH_TOKEN = 'apollo-token'
 // Http endpoint
 const httpEndpoint = process.env.VUE_APP_GRAPHQL_HTTP || 'http://localhost:4042/graphql'
 // Files URL root
-export const filesRoot = process.env.VUE_APP_FILES_ROOT || httpEndpoint.substr(0, httpEndpoint.indexOf('/graphql'))
+export const filesRoot = process.env.VUE_APP_FILES_ROOT || httpEndpoint.substring(0, httpEndpoint.indexOf('/graphql'))
 
 Vue.prototype.$filesRoot = filesRoot
 

--- a/packages/vue-apollo-util/src/errorLog.ts
+++ b/packages/vue-apollo-util/src/errorLog.ts
@@ -48,7 +48,7 @@ export function logErrorMessages (error: ApolloError | ErrorResponse, printStack
     if (stack == null) return
 
     const newLineIndex = stack.indexOf('\n')
-    stack = stack.substr(stack.indexOf('\n', newLineIndex + 1))
+    stack = stack.slice(stack.indexOf('\n', newLineIndex + 1))
     console.log(`%c${stack}`, 'color:grey;')
   }
 }


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) or [String.prototype.substring()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substring) which work similarily but aren't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.