### PR TITLE
fix: provideApollClient overriding specified query / mutation clientId

### DIFF
--- a/packages/vue-apollo-composable/src/useApolloClient.ts
+++ b/packages/vue-apollo-composable/src/useApolloClient.ts
@@ -42,10 +42,11 @@ export function useApolloClient<TCacheShape = any> (clientId?: ClientId): UseApo
     const providedApolloClient: ApolloClient<TCacheShape> | null = inject(DefaultApolloClient, null)
 
     resolveImpl = (id?: ClientId) => {
-      if (savedCurrentClient) {
-        return savedCurrentClient
-      } else if (id) {
+      if (id) {
         return resolveClientWithId(providedApolloClients, id)
+      }
+      else if (savedCurrentClient) {
+        return savedCurrentClient
       }
       return resolveDefaultClient(providedApolloClients, providedApolloClient)
     }


### PR DESCRIPTION
See original issue here: https://github.com/vuejs/apollo/issues/1337

**Problem:**
Vue Apollo is using the `savedCurrentClient` as the default client even when inside of a .vue file and a different clientId is being explicitly set by the query or mutation. This means that if you've set the client by using `provideApolloClient` at any point in the application's session, it's going to continue to use that client instead of the one you're specifying in the current query or mutation because that `savedCurrentClient` const is based on the `currentApolloClient` var. 

**Solution:**
I believe that these conditions should be swapped to look for a provided ID first and if one isn't provided then try and fallback to the savedCurrentClient. 

