### PR TITLE
feat: allow providing multiple apolloClients outside of setup/vue context in vue-apollo-composable

### DIFF
--- a/packages/docs/src/guide-composable/setup.md
+++ b/packages/docs/src/guide-composable/setup.md
@@ -82,3 +82,27 @@ provide(ApolloClients, {
 ```
 
 You can then select which one to use in functions we will cover next (such as `useQuery`, `useMutation` and `useSubscription`) with the `clientId` option.
+
+## Usage outside of setup
+
+When using e.g. `useQuery` outside of vue contexts, the clients cannot be injected using vue's provide/inject mechanism. `@vue/apollo-composable` can manage their own apollo clients
+
+Use `provideApolloClient` for a single default client:
+
+```js
+import { provideApolloClient } from "@vue/apollo-composable";
+
+provideApolloClient(apolloClient)
+```
+
+Use `provideApolloClients` for multiple clients:
+
+```js
+import { provideApolloClients } from "@vue/apollo-composable";
+
+provideApolloClients({
+  default: apolloClient,
+  clientA: apolloClientA,
+  clientB: apolloClientB,
+})
+```

--- a/packages/test-e2e-composable-vue3/src/components/NoSetupQueryMultiClient.vue
+++ b/packages/test-e2e-composable-vue3/src/components/NoSetupQueryMultiClient.vue
@@ -1,0 +1,35 @@
+<script lang="ts">
+import { apolloClient } from '@/apollo'
+import gql from 'graphql-tag'
+import { useQuery, useResult, provideApolloClients } from '@vue/apollo-composable'
+import { defineComponent } from 'vue'
+
+// Global query
+
+const query = provideApolloClients({ myCustomClientId: apolloClient })(() =>
+  useQuery(
+    gql`
+      query hello {
+        hello
+      }
+    `,
+    {},
+    { clientId: 'myCustomClientId' },
+  ),
+)
+const hello = useResult(query.result, [])
+
+export default defineComponent({
+  setup () {
+    return {
+      hello,
+    }
+  },
+})
+</script>
+
+<template>
+  <div class="no-setup-query">
+    {{ hello }}
+  </div>
+</template>

--- a/packages/test-e2e-composable-vue3/src/router.ts
+++ b/packages/test-e2e-composable-vue3/src/router.ts
@@ -19,6 +19,10 @@ export const router = createRouter({
       component: () => import('./components/NoSetupQuery.vue'),
     },
     {
+      path: '/no-setup-query-multi-client',
+      component: () => import('./components/NoSetupQueryMultiClient.vue'),
+    },
+    {
       path: '/lazy-query',
       component: () => import('./components/LazyQuery.vue'),
     },

--- a/packages/test-e2e-composable-vue3/tests/e2e/specs/test.js
+++ b/packages/test-e2e-composable-vue3/tests/e2e/specs/test.js
@@ -81,6 +81,11 @@ describe('Vue 3 + Apollo Composable', () => {
     cy.contains('.no-setup-query', 'Hello world!')
   })
 
+  it('supports queries outside of setup with multiple clients', () => {
+    cy.visit('/no-setup-query-multi-client')
+    cy.contains('.no-setup-query', 'Hello world!')
+  })
+
   it('useLazyQuery', () => {
     cy.visit('/lazy-query')
     cy.get('.list-disc').should('have.length', 0)

--- a/packages/vue-apollo-composable/src/index.ts
+++ b/packages/vue-apollo-composable/src/index.ts
@@ -43,4 +43,5 @@ export {
   useApolloClient,
   UseApolloClientReturn,
   provideApolloClient,
+  provideApolloClients,
 } from './useApolloClient'


### PR DESCRIPTION
## What?
- adds a `provideApolloClients` that mirrors the api of `app.provide(ApolloClients, { <clients> })` to allow using different apollo clients outside of `setup`/vue contexts (for "global queries")
- should also fix the issue in #1338 

## Why?
- It was impossible to use global queries/mutations outside of setup 

## How?
- `useApolloClients.ts` now maintains a `currentApolloClients` client dictionary instead of just a single client

I added an extra e2e test and a short section in the docs.