### PR TITLE
Make calls of the *refetch()* & *fetchMore()* trigger *loading* state

### DIFF
--- a/packages/vue-apollo-composable/src/useQuery.ts
+++ b/packages/vue-apollo-composable/src/useQuery.ts
@@ -431,6 +431,11 @@ export function useQueryImpl<
       error.value = null
       loading.value = true
       return query.value.refetch(variables)
+        .then((refetchResult) => {
+          const currentResult = query.value?.getCurrentResult()
+          currentResult && processNextResult(currentResult)
+          return refetchResult
+        })
     }
   }
 
@@ -439,7 +444,13 @@ export function useQueryImpl<
   function fetchMore (options: FetchMoreQueryOptions<TVariables, TResult> & FetchMoreOptions<TResult, TVariables>) {
     if (query.value) {
       error.value = null
+      loading.value = true
       return query.value.fetchMore(options)
+        .then((fetchMoreResult) => {
+          const currentResult = query.value?.getCurrentResult()
+          currentResult && processNextResult(currentResult)
+          return fetchMoreResult
+        })
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,4 +1,4 @@
-lockfileVersion: 5.4
+lockfileVersion: 5.3
 
 overrides:
   eslint-scope: ^5
@@ -28,10 +28,10 @@ importers:
       typescript: ^4.1.5
     devDependencies:
       '@akryum/sheep': 0.3.3
-      '@typescript-eslint/eslint-plugin': 4.33.0_lzzr7k3tjtqil7aczuhmzzwame
-      '@typescript-eslint/parser': 4.33.0_e4zyhrvfnqudwdx5bevnvkluy4
-      '@vue/eslint-config-standard': 6.1.0_prhfl54rv5bu2u3ooxppsjs65q
-      '@vue/eslint-config-typescript': 7.0.0_6la4ba6kt6f6k6jmpxfirguy4m
+      '@typescript-eslint/eslint-plugin': 4.33.0_5e731fab734ce085fc02cd0ecce6c061
+      '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.6.4
+      '@vue/eslint-config-standard': 6.1.0_7c4e55f791af434d536e75def9265eec
+      '@vue/eslint-config-typescript': 7.0.0_f2c1c083ca9f8be5792c7dca889a98e3
       conventional-changelog-cli: 2.2.2
       core-js: 3.22.4
       esbuild: 0.8.57
@@ -87,7 +87,7 @@ importers:
       vue-router: ^4.0.0
       vuex: ^4.0.0
     dependencies:
-      '@apollo/client': 3.6.2_nvv7ff2t7tnlinssgmzirzznsi
+      '@apollo/client': 3.6.2_6d6bf29753fcdab43652333288e72d92
       '@vue/apollo-components': link:../vue-apollo-components
       '@vue/apollo-option': link:../vue-apollo-option
       apollo-server-express: 2.25.3_graphql@15.8.0
@@ -102,11 +102,11 @@ importers:
       vue-router: 4.0.14_vue@3.2.33
       vuex: 4.0.2_vue@3.2.33
     devDependencies:
-      '@typescript-eslint/eslint-plugin': 4.33.0_lzzr7k3tjtqil7aczuhmzzwame
-      '@typescript-eslint/parser': 4.33.0_e4zyhrvfnqudwdx5bevnvkluy4
-      '@vue/cli-plugin-babel': 4.5.17_sw2p35sxudn5es5t2fs5e7v4yq
-      '@vue/cli-plugin-e2e-cypress': 4.5.17_ddrfendqzmvaadfa5ctobayk7i
-      '@vue/cli-service': 4.5.17_ryt3pfw5oduqzjninpd4rgwbru
+      '@typescript-eslint/eslint-plugin': 4.33.0_5e731fab734ce085fc02cd0ecce6c061
+      '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.6.4
+      '@vue/cli-plugin-babel': 4.5.17_95b4fdf657a0dbd24bb3d165d27ebcc4
+      '@vue/cli-plugin-e2e-cypress': 4.5.17_18e2523470cb2a000ca0e8a6e0830afa
+      '@vue/cli-service': 4.5.17_8e27b796dd70e90ca5a86bc7c89ac18d
       '@vue/compiler-sfc': 3.2.33
       esbuild: 0.8.57
       esbuild-node-externals: 1.4.1_esbuild@0.8.57
@@ -163,10 +163,10 @@ importers:
       vue-router: 4.0.14_vue@3.2.33
     devDependencies:
       '@types/shortid': 0.0.29
-      '@vue/cli-plugin-babel': 4.5.17_sw2p35sxudn5es5t2fs5e7v4yq
-      '@vue/cli-plugin-e2e-cypress': 4.5.17_@vue+cli-service@4.5.17
-      '@vue/cli-plugin-typescript': 4.5.17_j5xdgxskous64wzqkuyjb5i52e
-      '@vue/cli-service': 4.5.17_@vue+compiler-sfc@3.2.33
+      '@vue/cli-plugin-babel': 4.5.17_95b4fdf657a0dbd24bb3d165d27ebcc4
+      '@vue/cli-plugin-e2e-cypress': 4.5.17_18e2523470cb2a000ca0e8a6e0830afa
+      '@vue/cli-plugin-typescript': 4.5.17_83acf7a3f1ebea2a4655eeea56bc7f1b
+      '@vue/cli-service': 4.5.17_8aad6dca5972142f31276c25a1892fde
       '@vue/compiler-sfc': 3.2.33
       axios: 0.24.0
       kill-port: 1.6.1
@@ -215,7 +215,7 @@ importers:
       nodemon: 1.19.4
       rimraf: 3.0.2
       rollup: 1.32.1
-      rollup-plugin-babel: 4.4.0_d7pn3wqtbuzdunda4z5wtbe4v4
+      rollup-plugin-babel: 4.4.0_1fdeddda130d323a3460e67b69849caf
       rollup-plugin-commonjs: 10.1.0_rollup@1.32.1
       rollup-plugin-node-resolve: 5.2.0_rollup@1.32.1
       rollup-plugin-replace: 2.2.0
@@ -297,7 +297,7 @@ importers:
       nodemon: 1.19.4
       rimraf: 3.0.2
       rollup: 1.32.1
-      rollup-plugin-babel: 4.4.0_d7pn3wqtbuzdunda4z5wtbe4v4
+      rollup-plugin-babel: 4.4.0_1fdeddda130d323a3460e67b69849caf
       rollup-plugin-commonjs: 10.1.0_rollup@1.32.1
       rollup-plugin-node-resolve: 5.2.0_rollup@1.32.1
       rollup-plugin-replace: 2.2.0
@@ -500,39 +500,7 @@ packages:
       zen-observable-ts: 1.2.3
     dev: true
 
-  /@apollo/client/3.6.2_graphql@15.8.0:
-    resolution: {integrity: sha512-DNWyl+NNU2VsfHtXwOr4rV9hnQFPkl2/dNXeouhk9q7bXCWdEh3K8YTt/frULGVKbQjtnlPmz8C+LFI/JZ2N3w==}
-    peerDependencies:
-      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
-      graphql-ws: ^5.5.5
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      subscriptions-transport-ws: ^0.9.0 || ^0.11.0
-    peerDependenciesMeta:
-      graphql:
-        optional: true
-      graphql-ws:
-        optional: true
-      react:
-        optional: true
-      subscriptions-transport-ws:
-        optional: true
-    dependencies:
-      '@graphql-typed-document-node/core': 3.1.1_graphql@15.8.0
-      '@wry/context': 0.6.1
-      '@wry/equality': 0.5.2
-      '@wry/trie': 0.3.1
-      graphql: 15.8.0
-      graphql-tag: 2.12.6_graphql@15.8.0
-      hoist-non-react-statics: 3.3.2
-      optimism: 0.16.1
-      prop-types: 15.8.1
-      symbol-observable: 4.0.0
-      ts-invariant: 0.10.1
-      tslib: 2.4.0
-      use-sync-external-store: 1.1.0
-      zen-observable-ts: 1.2.3
-
-  /@apollo/client/3.6.2_nvv7ff2t7tnlinssgmzirzznsi:
+  /@apollo/client/3.6.2_6d6bf29753fcdab43652333288e72d92:
     resolution: {integrity: sha512-DNWyl+NNU2VsfHtXwOr4rV9hnQFPkl2/dNXeouhk9q7bXCWdEh3K8YTt/frULGVKbQjtnlPmz8C+LFI/JZ2N3w==}
     peerDependencies:
       graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
@@ -565,6 +533,38 @@ packages:
       use-sync-external-store: 1.1.0
       zen-observable-ts: 1.2.3
     dev: false
+
+  /@apollo/client/3.6.2_graphql@15.8.0:
+    resolution: {integrity: sha512-DNWyl+NNU2VsfHtXwOr4rV9hnQFPkl2/dNXeouhk9q7bXCWdEh3K8YTt/frULGVKbQjtnlPmz8C+LFI/JZ2N3w==}
+    peerDependencies:
+      graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+      graphql-ws: ^5.5.5
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      subscriptions-transport-ws: ^0.9.0 || ^0.11.0
+    peerDependenciesMeta:
+      graphql:
+        optional: true
+      graphql-ws:
+        optional: true
+      react:
+        optional: true
+      subscriptions-transport-ws:
+        optional: true
+    dependencies:
+      '@graphql-typed-document-node/core': 3.1.1_graphql@15.8.0
+      '@wry/context': 0.6.1
+      '@wry/equality': 0.5.2
+      '@wry/trie': 0.3.1
+      graphql: 15.8.0
+      graphql-tag: 2.12.6_graphql@15.8.0
+      hoist-non-react-statics: 3.3.2
+      optimism: 0.16.1
+      prop-types: 15.8.1
+      symbol-observable: 4.0.0
+      ts-invariant: 0.10.1
+      tslib: 2.4.0
+      use-sync-external-store: 1.1.0
+      zen-observable-ts: 1.2.3
 
   /@apollo/protobufjs/1.2.2:
     resolution: {integrity: sha512-vF+zxhPiLtkwxONs6YanSt1EpwpGilThpneExUN5K3tCymuxNnVq2yojTvnpRjv2QfsEIt/n7ozPIIzBLwGIDQ==}
@@ -2600,7 +2600,7 @@ packages:
       '@types/yargs-parser': 21.0.0
     dev: true
 
-  /@typescript-eslint/eslint-plugin/4.33.0_lzzr7k3tjtqil7aczuhmzzwame:
+  /@typescript-eslint/eslint-plugin/4.33.0_5e731fab734ce085fc02cd0ecce6c061:
     resolution: {integrity: sha512-aINiAxGVdOl1eJyVjaWn/YcVAq4Gi/Yo35qHGCnqbWVz61g39D0h23veY/MA0rFFGfxK7TySg2uwDeNv+JgVpg==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -2613,8 +2613,8 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/experimental-utils': 4.33.0_e4zyhrvfnqudwdx5bevnvkluy4
-      '@typescript-eslint/parser': 4.33.0_e4zyhrvfnqudwdx5bevnvkluy4
+      '@typescript-eslint/experimental-utils': 4.33.0_eslint@7.32.0+typescript@4.6.4
+      '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.6.4
       '@typescript-eslint/scope-manager': 4.33.0
       debug: 4.3.4
       eslint: 7.32.0
@@ -2628,7 +2628,7 @@ packages:
       - supports-color
     dev: true
 
-  /@typescript-eslint/experimental-utils/4.33.0_e4zyhrvfnqudwdx5bevnvkluy4:
+  /@typescript-eslint/experimental-utils/4.33.0_eslint@7.32.0+typescript@4.6.4:
     resolution: {integrity: sha512-zeQjOoES5JFjTnAhI5QY7ZviczMzDptls15GFsI6jyUOq0kOf9+WonkhtlIhh0RgHRnqj5gdNxW5j1EvAyYg6Q==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -2649,7 +2649,7 @@ packages:
       - typescript
     dev: true
 
-  /@typescript-eslint/parser/4.33.0_e4zyhrvfnqudwdx5bevnvkluy4:
+  /@typescript-eslint/parser/4.33.0_eslint@7.32.0+typescript@4.6.4:
     resolution: {integrity: sha512-ZohdsbXadjGBSK0/r+d87X0SBmKzOq4/S5nzK6SBgJspFo9/CUDJ7hjayuze+JK7CZQLDMroqytp7pOcFKTxZA==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -2875,16 +2875,16 @@ packages:
     resolution: {integrity: sha512-QKKp66VbMg+X8Qh0wgXSwgxLfxY7EIkZkV6bZ6nFqBx8xtaJQVDbTL+4zcUPPA6nygbIcQ6gvTinNEqIqX6FUQ==}
     dev: true
 
-  /@vue/cli-plugin-babel/4.5.17_sw2p35sxudn5es5t2fs5e7v4yq:
+  /@vue/cli-plugin-babel/4.5.17_95b4fdf657a0dbd24bb3d165d27ebcc4:
     resolution: {integrity: sha512-6kZuc3PdoUvGAnndUq6+GqjIXn3bqdTR8lOcAb1BH2b4N7IKGlmzcipALGS23HLVMAvDgNuUS7vf0unin9j2cg==}
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0-0
     dependencies:
       '@babel/core': 7.17.10
       '@vue/babel-preset-app': 4.5.17_vue@3.2.33
-      '@vue/cli-service': 4.5.17_@vue+compiler-sfc@3.2.33
+      '@vue/cli-service': 4.5.17_8aad6dca5972142f31276c25a1892fde
       '@vue/cli-shared-utils': 4.5.17
-      babel-loader: 8.2.5_usdhdj5awexcm2e5jtwd44bofa
+      babel-loader: 8.2.5_a48671a7a0b12e26689d4cec3e702e28
       cache-loader: 4.1.0_webpack@4.46.0
       thread-loader: 2.1.3_webpack@4.46.0
       webpack: 4.46.0
@@ -2895,25 +2895,12 @@ packages:
       - webpack-command
     dev: true
 
-  /@vue/cli-plugin-e2e-cypress/4.5.17_@vue+cli-service@4.5.17:
+  /@vue/cli-plugin-e2e-cypress/4.5.17_18e2523470cb2a000ca0e8a6e0830afa:
     resolution: {integrity: sha512-mSOl7rEt4DbVfvly0VFbuKPu+NeWptXLrNg+MTIzQT3QkW6+e1XxRaeDBdQ80/Gcb5HtpjGIYgDb8fvrxPIcDg==}
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0-0
     dependencies:
-      '@vue/cli-service': 4.5.17_@vue+compiler-sfc@3.2.33
-      '@vue/cli-shared-utils': 4.5.17
-      cypress: 3.8.3
-      eslint-plugin-cypress: 2.12.1
-    transitivePeerDependencies:
-      - eslint
-    dev: true
-
-  /@vue/cli-plugin-e2e-cypress/4.5.17_ddrfendqzmvaadfa5ctobayk7i:
-    resolution: {integrity: sha512-mSOl7rEt4DbVfvly0VFbuKPu+NeWptXLrNg+MTIzQT3QkW6+e1XxRaeDBdQ80/Gcb5HtpjGIYgDb8fvrxPIcDg==}
-    peerDependencies:
-      '@vue/cli-service': ^3.0.0 || ^4.0.0-0
-    dependencies:
-      '@vue/cli-service': 4.5.17_ryt3pfw5oduqzjninpd4rgwbru
+      '@vue/cli-service': 4.5.17_8aad6dca5972142f31276c25a1892fde
       '@vue/cli-shared-utils': 4.5.17
       cypress: 3.8.3
       eslint-plugin-cypress: 2.12.1_eslint@7.32.0
@@ -2926,11 +2913,11 @@ packages:
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0-0
     dependencies:
-      '@vue/cli-service': 4.5.17_@vue+compiler-sfc@3.2.33
+      '@vue/cli-service': 4.5.17_8aad6dca5972142f31276c25a1892fde
       '@vue/cli-shared-utils': 4.5.17
     dev: true
 
-  /@vue/cli-plugin-typescript/4.5.17_j5xdgxskous64wzqkuyjb5i52e:
+  /@vue/cli-plugin-typescript/4.5.17_83acf7a3f1ebea2a4655eeea56bc7f1b:
     resolution: {integrity: sha512-7JeJ913td1xbNKcVO71clTEXWGq43/6FPLhph3kBEdUrMqANd1ENb4jFZ/Rl277YTFipV08WpzQ12d1ZtqwvEQ==}
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0-0
@@ -2943,15 +2930,16 @@ packages:
         optional: true
     dependencies:
       '@types/webpack-env': 1.16.4
-      '@vue/cli-service': 4.5.17_@vue+compiler-sfc@3.2.33
+      '@vue/cli-service': 4.5.17_8aad6dca5972142f31276c25a1892fde
       '@vue/cli-shared-utils': 4.5.17
       '@vue/compiler-sfc': 3.2.33
       cache-loader: 4.1.0_webpack@4.46.0
       fork-ts-checker-webpack-plugin: 3.1.1
       globby: 9.2.0
       thread-loader: 2.1.3_webpack@4.46.0
-      ts-loader: 6.2.2
-      tslint: 5.20.1
+      ts-loader: 6.2.2_typescript@4.6.4
+      tslint: 5.20.1_typescript@4.6.4
+      typescript: 4.6.4
       webpack: 4.46.0
       yorkie: 2.0.0
     optionalDependencies:
@@ -2966,10 +2954,10 @@ packages:
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0-0
     dependencies:
-      '@vue/cli-service': 4.5.17_@vue+compiler-sfc@3.2.33
+      '@vue/cli-service': 4.5.17_8aad6dca5972142f31276c25a1892fde
     dev: true
 
-  /@vue/cli-service/4.5.17_@vue+compiler-sfc@3.2.33:
+  /@vue/cli-service/4.5.17_8aad6dca5972142f31276c25a1892fde:
     resolution: {integrity: sha512-MqfkRYIcIUACe3nYlzNrYstJTWRXHlIqh6JCkbWbdnXWN+IfaVdlG8zw5Q0DVcSdGvkevUW7zB4UhtZB4uyAcA==}
     engines: {node: '>=8'}
     hasBin: true
@@ -3009,7 +2997,7 @@ packages:
       '@vue/cli-shared-utils': 4.5.17
       '@vue/compiler-sfc': 3.2.33
       '@vue/component-compiler-utils': 3.3.0
-      '@vue/preload-webpack-plugin': 1.1.2_kawgdd6iu7jv34d6smtvgjfc2a
+      '@vue/preload-webpack-plugin': 1.1.2_502c618fc8a7d35df07e93275324a2d0
       '@vue/web-component-wrapper': 1.3.0
       acorn: 7.4.1
       acorn-walk: 7.2.0
@@ -3039,14 +3027,14 @@ packages:
       lodash.transform: 4.6.0
       mini-css-extract-plugin: 0.9.0_webpack@4.46.0
       minimist: 1.2.6
-      pnp-webpack-plugin: 1.7.0
+      pnp-webpack-plugin: 1.7.0_typescript@4.6.4
       portfinder: 1.0.28
       postcss-loader: 3.0.0
       ssri: 8.0.1
       terser-webpack-plugin: 1.4.5_webpack@4.46.0
       thread-loader: 2.1.3_webpack@4.46.0
-      url-loader: 2.3.0_ke5umg2s3o4akbat3qvdol7cby
-      vue-loader: 15.9.8_bkw5dbximtedzkysqs5ok2gwvy
+      url-loader: 2.3.0_file-loader@4.3.0+webpack@4.46.0
+      vue-loader: 15.9.8_0aadd186e864c83cab1284bae568d6ae
       vue-style-loader: 4.1.3
       webpack: 4.46.0
       webpack-bundle-analyzer: 3.9.0
@@ -3062,7 +3050,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@vue/cli-service/4.5.17_ryt3pfw5oduqzjninpd4rgwbru:
+  /@vue/cli-service/4.5.17_8e27b796dd70e90ca5a86bc7c89ac18d:
     resolution: {integrity: sha512-MqfkRYIcIUACe3nYlzNrYstJTWRXHlIqh6JCkbWbdnXWN+IfaVdlG8zw5Q0DVcSdGvkevUW7zB4UhtZB4uyAcA==}
     engines: {node: '>=8'}
     hasBin: true
@@ -3102,7 +3090,7 @@ packages:
       '@vue/cli-shared-utils': 4.5.17
       '@vue/compiler-sfc': 3.2.33
       '@vue/component-compiler-utils': 3.3.0
-      '@vue/preload-webpack-plugin': 1.1.2_kawgdd6iu7jv34d6smtvgjfc2a
+      '@vue/preload-webpack-plugin': 1.1.2_502c618fc8a7d35df07e93275324a2d0
       '@vue/web-component-wrapper': 1.3.0
       acorn: 7.4.1
       acorn-walk: 7.2.0
@@ -3139,8 +3127,8 @@ packages:
       stylus-loader: 3.0.2_stylus@0.54.8
       terser-webpack-plugin: 1.4.5_webpack@4.46.0
       thread-loader: 2.1.3_webpack@4.46.0
-      url-loader: 2.3.0_ke5umg2s3o4akbat3qvdol7cby
-      vue-loader: 15.9.8_bkw5dbximtedzkysqs5ok2gwvy
+      url-loader: 2.3.0_file-loader@4.3.0+webpack@4.46.0
+      vue-loader: 15.9.8_0aadd186e864c83cab1284bae568d6ae
       vue-style-loader: 4.1.3
       webpack: 4.46.0
       webpack-bundle-analyzer: 3.9.0
@@ -3226,7 +3214,7 @@ packages:
     resolution: {integrity: sha512-IiA0SvDrJEgXvVxjNkHPFfDx6SXw0b/TUkqMcDZWNg9fnCAHbTpoo59YfJ9QLFkwa3raau5vSlRVzMSLDnfdtQ==}
     dev: false
 
-  /@vue/eslint-config-standard/6.1.0_prhfl54rv5bu2u3ooxppsjs65q:
+  /@vue/eslint-config-standard/6.1.0_7c4e55f791af434d536e75def9265eec:
     resolution: {integrity: sha512-9+hrEyflDzsGdlBDl9jPV5DIYUx1TOU5OSQqRDKCrNumrxRj5HRWKuk+ocXWnha6uoNRtLC24mY7d/MwqvBCNw==}
     peerDependencies:
       '@vue/cli-service': ^3.0.0 || ^4.0.0 || ^5.0.0-0
@@ -3242,9 +3230,9 @@ packages:
         optional: true
     dependencies:
       eslint: 7.32.0
-      eslint-config-standard: 16.0.3_x4ksp4i5em7khivw5kkmm7swui
+      eslint-config-standard: 16.0.3_bf1527f11d233ea3a2b6ea94c67e56a2
       eslint-import-resolver-node: 0.3.6
-      eslint-import-resolver-webpack: 0.13.2_fkfqfehjtk7sk2efaqbgxsuasa
+      eslint-import-resolver-webpack: 0.13.2_eslint-plugin-import@2.26.0
       eslint-plugin-import: 2.26.0_eslint@7.32.0
       eslint-plugin-node: 11.1.0_eslint@7.32.0
       eslint-plugin-promise: 4.3.1
@@ -3253,7 +3241,7 @@ packages:
       - webpack
     dev: true
 
-  /@vue/eslint-config-typescript/7.0.0_6la4ba6kt6f6k6jmpxfirguy4m:
+  /@vue/eslint-config-typescript/7.0.0_f2c1c083ca9f8be5792c7dca889a98e3:
     resolution: {integrity: sha512-UxUlvpSrFOoF8aQ+zX1leYiEBEm7CZmXYn/ZEM1zwSadUzpamx56RB4+Htdjisv1mX2tOjBegNUqH3kz2OL+Aw==}
     engines: {node: ^10.12.0 || >=12.0.0}
     peerDependencies:
@@ -3265,8 +3253,8 @@ packages:
       eslint:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 4.33.0_lzzr7k3tjtqil7aczuhmzzwame
-      '@typescript-eslint/parser': 4.33.0_e4zyhrvfnqudwdx5bevnvkluy4
+      '@typescript-eslint/eslint-plugin': 4.33.0_5e731fab734ce085fc02cd0ecce6c061
+      '@typescript-eslint/parser': 4.33.0_eslint@7.32.0+typescript@4.6.4
       eslint: 7.32.0
       eslint-plugin-vue: 7.20.0_eslint@7.32.0
       vue-eslint-parser: 7.11.0_eslint@7.32.0
@@ -3274,7 +3262,7 @@ packages:
       - supports-color
     dev: true
 
-  /@vue/preload-webpack-plugin/1.1.2_kawgdd6iu7jv34d6smtvgjfc2a:
+  /@vue/preload-webpack-plugin/1.1.2_502c618fc8a7d35df07e93275324a2d0:
     resolution: {integrity: sha512-LIZMuJk38pk9U9Ur4YzHjlIyMuxPlACdBIHH9/nGYVTsaGKOSnSuELiE8vS9wa+dJpIYspYUOqk+L1Q4pgHQHQ==}
     engines: {node: '>=6.0.0'}
     peerDependencies:
@@ -4220,7 +4208,7 @@ packages:
       - supports-color
     dev: true
 
-  /babel-loader/8.2.5_usdhdj5awexcm2e5jtwd44bofa:
+  /babel-loader/8.2.5_a48671a7a0b12e26689d4cec3e702e28:
     resolution: {integrity: sha512-OSiFfH89LrEMiWd4pLNqGz4CwJDtbs2ZVc+iGu2HrkRfPxId9F2anQj38IxWpmRfsUY0aBZYi1EFcd3mhtRMLQ==}
     engines: {node: '>= 8.9'}
     peerDependencies:
@@ -4781,7 +4769,7 @@ packages:
     dev: true
 
   /chalk/1.1.3:
-    resolution: {integrity: sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=}
+    resolution: {integrity: sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==}
     engines: {node: '>=0.10.0'}
     dependencies:
       ansi-styles: 2.2.1
@@ -6292,7 +6280,7 @@ packages:
     dev: true
 
   /emojis-list/2.1.0:
-    resolution: {integrity: sha1-TapNnbAPmBmIDHn6RXrlsJof04k=}
+    resolution: {integrity: sha512-knHEZMgs8BB+MInokmNTg/OyPlAddghe1YBgNwJBc5zsJi/uyIcXoSDsL/W9ymOsBoBGdPIHXYJ9+qKFwRwDng==}
     engines: {node: '>= 0.10'}
     dev: true
 
@@ -6658,7 +6646,7 @@ packages:
       source-map: 0.6.1
     dev: true
 
-  /eslint-config-standard/16.0.3_x4ksp4i5em7khivw5kkmm7swui:
+  /eslint-config-standard/16.0.3_bf1527f11d233ea3a2b6ea94c67e56a2:
     resolution: {integrity: sha512-x4fmJL5hGqNJKGHSjnLdgA6U6h1YW/G2dW9fA+cyVur4SK6lyue8+UgNKWlZtUDTXvgKDD/Oa3GQjmB5kjtVvg==}
     peerDependencies:
       eslint: '*'
@@ -6682,7 +6670,7 @@ packages:
       resolve: 1.22.0
     dev: true
 
-  /eslint-import-resolver-webpack/0.13.2_fkfqfehjtk7sk2efaqbgxsuasa:
+  /eslint-import-resolver-webpack/0.13.2_eslint-plugin-import@2.26.0:
     resolution: {integrity: sha512-XodIPyg1OgE2h5BDErz3WJoK7lawxKTJNhgPNafRST6csC/MZC+L5P6kKqsZGRInpbgc02s/WZMrb4uGJzcuRg==}
     engines: {node: '>= 6'}
     peerDependencies:
@@ -6712,17 +6700,6 @@ packages:
     dependencies:
       debug: 3.2.7
       find-up: 2.1.0
-    dev: true
-
-  /eslint-plugin-cypress/2.12.1:
-    resolution: {integrity: sha512-c2W/uPADl5kospNDihgiLc7n87t5XhUbFDoTl6CfVkmG+kDAb5Ux10V9PoLPu9N+r7znpc+iQlcmAqT1A/89HA==}
-    peerDependencies:
-      eslint: '*'
-    peerDependenciesMeta:
-      eslint:
-        optional: true
-    dependencies:
-      globals: 11.12.0
     dev: true
 
   /eslint-plugin-cypress/2.12.1_eslint@7.32.0:
@@ -8534,7 +8511,7 @@ packages:
     dev: true
 
   /is-arrayish/0.2.1:
-    resolution: {integrity: sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=}
+    resolution: {integrity: sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==}
     dev: true
 
   /is-arrayish/0.3.2:
@@ -9478,7 +9455,7 @@ packages:
     dev: true
 
   /json5/0.5.1:
-    resolution: {integrity: sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=}
+    resolution: {integrity: sha512-4xrs1aW+6N5DalkqSVA8fxh458CXvR99WU8WLKmq4v8eWAL86Xo3BVqyd3SkA9wEVjCMqyvvRRkshAdOnBp5rw==}
     hasBin: true
     dev: true
 
@@ -11040,15 +11017,6 @@ packages:
     resolution: {integrity: sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==}
     dev: true
 
-  /pnp-webpack-plugin/1.7.0:
-    resolution: {integrity: sha512-2Rb3vm+EXble/sMXNSu6eoBx8e79gKqhNq9F5ZWW6ERNCTE/Q0wQNne5541tE5vKjfM8hpNCYL+LGc1YTfI0dg==}
-    engines: {node: '>=6'}
-    dependencies:
-      ts-pnp: 1.2.0
-    transitivePeerDependencies:
-      - typescript
-    dev: true
-
   /pnp-webpack-plugin/1.7.0_typescript@4.6.4:
     resolution: {integrity: sha512-2Rb3vm+EXble/sMXNSu6eoBx8e79gKqhNq9F5ZWW6ERNCTE/Q0wQNne5541tE5vKjfM8hpNCYL+LGc1YTfI0dg==}
     engines: {node: '>=6'}
@@ -12145,7 +12113,7 @@ packages:
       inherits: 2.0.4
     dev: true
 
-  /rollup-plugin-babel/4.4.0_d7pn3wqtbuzdunda4z5wtbe4v4:
+  /rollup-plugin-babel/4.4.0_1fdeddda130d323a3460e67b69849caf:
     resolution: {integrity: sha512-Lek/TYp1+7g7I+uMfJnnSJ7YWoD58ajo6Oarhlex7lvUce+RCKRuGRSgztDO3/MF/PuGKmUL5iTHKf208UNszw==}
     deprecated: This package has been deprecated and is no longer maintained. Please use @rollup/plugin-babel.
     peerDependencies:
@@ -13433,7 +13401,7 @@ packages:
       tslib: 1.14.1
     dev: false
 
-  /ts-loader/6.2.2:
+  /ts-loader/6.2.2_typescript@4.6.4:
     resolution: {integrity: sha512-HDo5kXZCBml3EUPcc7RlZOV/JGlLHwppTLEHb3SHnr5V7NXD4klMEkrhJe5wgRbaWsSXi+Y1SIBN/K9B6zWGWQ==}
     engines: {node: '>=8.6'}
     peerDependencies:
@@ -13447,16 +13415,7 @@ packages:
       loader-utils: 1.4.0
       micromatch: 4.0.5
       semver: 6.3.0
-    dev: true
-
-  /ts-pnp/1.2.0:
-    resolution: {integrity: sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==}
-    engines: {node: '>=6'}
-    peerDependencies:
-      typescript: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
+      typescript: 4.6.4
     dev: true
 
   /ts-pnp/1.2.0_typescript@4.6.4:
@@ -13490,7 +13449,7 @@ packages:
   /tslib/2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
 
-  /tslint/5.20.1:
+  /tslint/5.20.1_typescript@4.6.4:
     resolution: {integrity: sha512-EcMxhzCFt8k+/UP5r8waCf/lzmeSyVlqxqMEDQE7rWYiQky8KpIBz1JAoYXfROHrPZ1XXd43q8yQnULOLiBRQg==}
     engines: {node: '>=4.8.0'}
     hasBin: true
@@ -13512,10 +13471,11 @@ packages:
       resolve: 1.22.0
       semver: 5.7.1
       tslib: 1.14.1
-      tsutils: 2.29.0
+      tsutils: 2.29.0_typescript@4.6.4
+      typescript: 4.6.4
     dev: true
 
-  /tsutils/2.29.0:
+  /tsutils/2.29.0_typescript@4.6.4:
     resolution: {integrity: sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==}
     peerDependencies:
       typescript: '>=2.1.0 || >=2.1.0-dev || >=2.2.0-dev || >=2.3.0-dev || >=2.4.0-dev || >=2.5.0-dev || >=2.6.0-dev || >=2.7.0-dev || >=2.8.0-dev || >=2.9.0-dev || >= 3.0.0-dev || >= 3.1.0-dev'
@@ -13524,6 +13484,7 @@ packages:
         optional: true
     dependencies:
       tslib: 1.14.1
+      typescript: 4.6.4
     dev: true
 
   /tsutils/3.21.0_typescript@4.6.4:
@@ -13774,7 +13735,7 @@ packages:
     deprecated: Please see https://github.com/lydell/urix#deprecated
     dev: true
 
-  /url-loader/2.3.0_ke5umg2s3o4akbat3qvdol7cby:
+  /url-loader/2.3.0_file-loader@4.3.0+webpack@4.46.0:
     resolution: {integrity: sha512-goSdg8VY+7nPZKUEChZSEtW5gjbS66USIGCeSJ1OVOJ7Yfuh/36YxCwMi5HVEJh6mqUYOoy3NJ0vlOMrWsSHog==}
     engines: {node: '>= 8.9.0'}
     peerDependencies:
@@ -14016,7 +13977,7 @@ packages:
     resolution: {integrity: sha512-BXq3jwIagosjgNVae6tkHzzIk6a8MHFtzAdwhnV5VlvPTFxDCvIttgSiHWjdGoTJvXtmRu5HacExfdarRcFhog==}
     dev: true
 
-  /vue-loader/15.9.8_bkw5dbximtedzkysqs5ok2gwvy:
+  /vue-loader/15.9.8_0aadd186e864c83cab1284bae568d6ae:
     resolution: {integrity: sha512-GwSkxPrihfLR69/dSV3+5CdMQ0D+jXg8Ma1S4nQXKJAznYFX14vHdc/NetQc34Dw+rBbIJyP7JOuVb9Fhprvog==}
     peerDependencies:
       cache-loader: '*'


### PR DESCRIPTION
### Description
This PR makes call of the `refetch()` or `fetchMore()` trigger `loading.value` to change.

### Motivation
First, this [issue](https://github.com/vuejs/apollo/issues/1361).
Second, is in the previous version of vue-apollo, `$apollo.queries["query-name"].loading` was changed every time when we call `fetchMore()`/`refetch()` or just changed values of the variables. And such behavior was very handy, reliable and expectable.
Now, call of the `refetch()` sets `true` into `loading.value`, but doesn't set `false` when refetching is complete. `fatchMore()` doesn't change value of `loading.value` at all.
Enabling `notifyOnNetworkStatusChange` option is not a good idea, bc on the same page we can have several components and if both of them enable such  `notifyOnNetworkStatusChange`, both will show their loading states while only one component called `refetch()`/`fetchMore()` etc.
Loading state in one component has to stay independent from loading states of other components.

### Testing notes
All tests are passed.