### PR TITLE
fix: Root instance not found when using with Vue 2.7

### DIFF
--- a/packages/vue-apollo-composable/src/util/loadingTracking.ts
+++ b/packages/vue-apollo-composable/src/util/loadingTracking.ts
@@ -13,7 +13,7 @@ export interface AppLoadingTracking extends LoadingTracking {
 
 export function getAppTracking () {
   const vm = getCurrentInstance() as CurrentInstance | null
-  const root = vm?.$root ?? vm?.root  ?? vm?.proxy?.$root as CurrentInstance | null | undefined
+  const root = vm?.$root ?? vm?.root ?? vm?.proxy?.$root as CurrentInstance | null | undefined
   if (!root) {
     throw new Error('Instance $root not found')
   }

--- a/packages/vue-apollo-composable/src/util/loadingTracking.ts
+++ b/packages/vue-apollo-composable/src/util/loadingTracking.ts
@@ -13,7 +13,7 @@ export interface AppLoadingTracking extends LoadingTracking {
 
 export function getAppTracking () {
   const vm = getCurrentInstance() as CurrentInstance | null
-  let root = vm?.$root ?? vm?.root  ?? vm?.proxy?.$root as CurrentInstance | null | undefined
+  const root = vm?.$root ?? vm?.root  ?? vm?.proxy?.$root as CurrentInstance | null | undefined
   if (!root) {
     throw new Error('Instance $root not found')
   }

--- a/packages/vue-apollo-composable/src/util/loadingTracking.ts
+++ b/packages/vue-apollo-composable/src/util/loadingTracking.ts
@@ -13,7 +13,7 @@ export interface AppLoadingTracking extends LoadingTracking {
 
 export function getAppTracking () {
   const vm = getCurrentInstance() as CurrentInstance | null
-  const root = vm?.$root ?? vm?.root
+  let root = vm?.$root ?? vm?.root  ?? vm?.proxy?.$root as CurrentInstance | null | undefined
   if (!root) {
     throw new Error('Instance $root not found')
   }


### PR DESCRIPTION
This fixes the issue described in [issue 1337](https://github.com/vuejs/apollo/issues/1377) when using Vue 2.7.

I added a fallback to vm.proxy.$root in case vm.root is not defined. If it is, however, this patch won't break anything.

closes #1377 
