### PR TITLE
fix: do not destroy $apollo during serverPrefect

### DIFF
--- a/packages/vue-apollo-option/src/mixin.js
+++ b/packages/vue-apollo-option/src/mixin.js
@@ -125,10 +125,7 @@ export function installMixin (app, provider) {
 
     serverPrefetch () {
       if (this.$_apolloPromises) {
-        return Promise.all(this.$_apolloPromises).then(() => {
-          destroy.call(this)
-        }).catch(e => {
-          destroy.call(this)
+        return Promise.all(this.$_apolloPromises).catch(e => {
           return Promise.reject(e)
         })
       }


### PR DESCRIPTION
Fixes: https://github.com/vuejs/apollo/issues/1297

Package: Apollo Option

Situation: $apollo gets destroyed during serverPrefetch, this triggers server errors in components that use $apollo.

Solution proposed: Do not destroy $apollo during serverPrefetch lifecycle method.

Code sandbox showing the error: https://codesandbox.io/s/nuxt-3-ssr-apollo-option-srw1jw?file=/pages/index.vue
