### PR TITLE
fix(composable): Remove immediate result logic

### DIFF
--- a/packages/vue-apollo-composable/src/useQuery.ts
+++ b/packages/vue-apollo-composable/src/useQuery.ts
@@ -228,14 +228,6 @@ export function useQueryImpl<
 
     startQuerySubscription()
 
-    if (!isServer && (currentOptions.value?.fetchPolicy !== 'no-cache' || currentOptions.value.notifyOnNetworkStatusChange)) {
-      const currentResult = query.value.getCurrentResult()
-
-      if (!currentResult.loading || currentResult.partial || currentOptions.value?.notifyOnNetworkStatusChange) {
-        onNextResult(currentResult)
-      }
-    }
-
     if (!isServer) {
       for (const item of subscribeToMoreItems) {
         addSubscribeToMore(item)


### PR DESCRIPTION
This old piece of code tried to get the result immediately by calling
getCurrentResult(), except that the function will also set the internal "last"
result if called without a `false` argument. This prevents `observer.next`
from being called with the same initial value.

The old code also conditionally ignored the result it just grabbed, and as a
result the initial value ended up not being passed on to the application.

The official Apollo React implementation does not have such special casing
and simply grabs the result whenever `observer.next` is called. Align our
code to that.

Issue: https://github.com/vuejs/apollo/issues/1315