### PR TITLE
docs: subscribeToMore / updateQuery 

### DIFF
--- a/packages/docs/src/guide-composable/subscription.md
+++ b/packages/docs/src/guide-composable/subscription.md
@@ -545,8 +545,9 @@ subscribeToMore(() => ({
     channelId: props.channelId
   },
   updateQuery: (previousResult, { subscriptionData }) => {
-    previousResult.messages.push(subscriptionData.data.messageAdded)
-    return previousResult
+    const tmp = [...previousResult] 
+    tmp.messages.push(subscriptionData.data.messageAdded)
+    return tmp
   }
 }))
 ```


### PR DESCRIPTION
since previousResult is immutable (in apollo 3), docs should cover this.

making a copy of the array and then push to it. returning the tmp as result

should fix #1394 