### PR TITLE
fix: enabled triggers prematurely

### DIFF
--- a/packages/vue-apollo-composable/src/useQuery.ts
+++ b/packages/vue-apollo-composable/src/useQuery.ts
@@ -500,7 +500,9 @@ export function useQueryImpl<
   // Auto start & stop
   watch(isEnabled, value => {
     if (value) {
-      start()
+      nextTick(() => {
+        start()
+      })
     } else {
       stop()
     }


### PR DESCRIPTION
Closes: https://github.com/vuejs/apollo/issues/1422

seems like the query is triggering too early before the variables was properly updated. 
Not sure what would be the best approach, but this does fix the issue above