### PR TITLE
docs: Subscriptions configuration docs updated to describe graphql-ws configuration.

### DIFF
--- a/packages/docs/src/guide-composable/subscription.md
+++ b/packages/docs/src/guide-composable/subscription.md
@@ -117,7 +117,7 @@ const apolloClient = new ApolloClient({
   cache: new InMemoryCache(),
 });
 ```
-The apollo client is the one that will be provided to the vue app, see the [setup section](https://v4.apollo.vuejs.org/guide-composable/setup.html) for more deatils
+The apollo client is the one that will be provided to the vue app, see the [setup section](https://v4.apollo.vuejs.org/guide-composable/setup.html) for more details.
 
 Now, queries and mutations will go over HTTP as normal, but subscriptions will be done over the websocket transport.
 ### The old library: **subscriptions-transport-ws**

--- a/packages/docs/src/guide-composable/subscription.md
+++ b/packages/docs/src/guide-composable/subscription.md
@@ -55,26 +55,33 @@ A future version of Apollo or GraphQL might include support for live queries, wh
 
 In this article, we'll explain how to set it up on the client, but you'll also need a server implementation. You can [read about how to use subscriptions with a JavaScript server](https://www.apollographql.com/docs/graphql-subscriptions/setup), or enjoy subscriptions set up out of the box if you are using a GraphQL backend as a service like [Graphcool](https://www.graph.cool/docs/tutorials/worldchat-subscriptions-example-ui0eizishe/).
 
-Let's look at how to add support for this transport to Apollo Client.
+The GraphQL spec does not define a specific protocol for sending subscription requests. The first popular JavaScript library to implement subscriptions over WebSocket is called *subscriptions-transport-ws*. This library is no longer actively maintained. Its successor is a library called *graphql-ws*. The two libraries do not use the same WebSocket subprotocol, so you need to make sure that your server and clients all use the same library.
 
-First, initialize a GraphQL web socket link:
+Apollo Client supports both *graphql-ws* and *subscriptions-transport-ws*. Apollo [documentation](https://www.apollographql.com/docs/react/data/subscriptions/#choosing-a-subscription-library) suggest to use the newer library *graphql-ws*, but in case you need it, here its explained how to do it with both.
+
+### The new library: **graphql-ws**
+Let's look at how to add support for this transport to Apollo Client using a link set up for newest library [graphql-ws](https://github.com/enisdenjo/graphql-ws). First, install: 
+```bash
+npm install graphql-ws
+```
+Then initialize a GraphQL web socket link:
 
 ```js
-import { WebSocketLink } from "@apollo/client/link/ws"
+import { GraphQLWsLink } from "@apollo/client/link/subscriptions";
+import { createClient } from "graphql-ws";
 
-const wsLink = new WebSocketLink({
-  uri: `ws://localhost:5000/`,
-  options: {
-    reconnect: true
-  }
-})
+const wsLink = new GraphQLWsLink(
+  createClient({
+    url: "ws://localhost:4000/graphql",
+  })
+);
 ```
 
-We need to either use the `WebSocketLink` or the `HttpLink` depending on the operation type:
+We need to either use the `GraphQLWsLink` or the `HttpLink` depending on the operation type:
 
 ```js
 import { HttpLink, split } from "@apollo/client/core"
-import { WebSocketLink } from "@apollo/client/link/ws"
+import { GraphQLWsLink } from "@apollo/client/link/subscriptions"; // <-- This one uses graphql-ws
 import { getMainDefinition } from "@apollo/client/utilities"
 
 // Create an http link:
@@ -82,13 +89,12 @@ const httpLink = new HttpLink({
   uri: "http://localhost:3000/graphql"
 })
 
-// Create a WebSocket link:
-const wsLink = new WebSocketLink({
-  uri: `ws://localhost:5000/`,
-  options: {
-    reconnect: true
-  }
-})
+// Create a GraphQLWsLink link:
+const wsLink = new GraphQLWsLink(
+  createClient({
+    url: "ws://localhost:5000/",
+  })
+);
 
 // using the ability to split links, you can send data to each link
 // depending on what kind of operation is being sent
@@ -104,9 +110,33 @@ const link = split(
   wsLink,
   httpLink
 )
+
+// Create the apollo client with cache implementation.
+const apolloClient = new ApolloClient({
+  link,
+  cache: new InMemoryCache(),
+});
 ```
+The apollo client is the one that will be provided to the vue app, see the [setup section](https://v4.apollo.vuejs.org/guide-composable/setup.html) for more deatils
 
 Now, queries and mutations will go over HTTP as normal, but subscriptions will be done over the websocket transport.
+### The old library: **subscriptions-transport-ws**
+If you need to use [subscriptions-transport-ws](https://github.com/apollographql/subscriptions-transport-ws) because your server still uses that protocol, instead of installing graphql-ws, install:
+```bash
+npm install subscriptions-transport-ws
+```
+And then initialize a GraphQL web socket link:
+```js
+import { WebSocketLink } from "@apollo/client/link/ws" // <-- This one uses subscriptions-transport-ws
+
+const wsLink = new WebSocketLink({
+  uri: `ws://localhost:5000/`,
+  options: {
+    reconnect: true
+  }
+})
+```
+The rest of the configuration (creating a httpLink and link) is the same as described above for graphql-ws.
 
 ## useSubscription
 


### PR DESCRIPTION
Referencing to this discussion https://github.com/vuejs/apollo/discussions/1351, I think the documentation should explain by default how to set up subscriptions with the apollo link object that uses *graphql-ws* instead of the deprecated *subscriptions-transport-ws*.
So I am suggesting to change the documentation that describes the set up for subscription how to do it with a link GraphQLWsLink and after that, just in case sombody needs to keep connecting to a server that still uses *subscriptions-transport-ws*, it explains how to use WebSocketLink.