### PR TITLE
fix: @vue/apollo-composable ESM settings, fix #1462

### DIFF
--- a/packages/vue-apollo-composable/esbuild.mjs
+++ b/packages/vue-apollo-composable/esbuild.mjs
@@ -13,7 +13,7 @@ import { nodeExternalsPlugin } from 'esbuild-node-externals'
 (async () => {
   /** @type {Build[]} */
   const builds = [
-    { format: 'esm', file: 'index.esm.js' },
+    { format: 'esm', file: 'index.mjs' },
     { format: 'cjs', file: 'index.js' },
   ]
   for (const { format, file } of builds) {

--- a/packages/vue-apollo-composable/package.json
+++ b/packages/vue-apollo-composable/package.json
@@ -24,11 +24,11 @@
   },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
-  "module": "dist/index.esm.js",
+  "module": "dist/index.mjs",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.js"
     },
     "./*": "./*"


### PR DESCRIPTION
I get the following error when importing the @vue/apollo-composable package.

```
(node:79376) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(myworkspace)/node_modules/@vue/apollo-composable/dist/index.esm.js:2
import {
^^^^^^

SyntaxError: Cannot use import statement outside a module
```

Because of this, the same error occurs when running `ssrLoadModule` in vite.