### PR TITLE
fix: import serializeJs using default import instead of a namespace import

### DIFF
--- a/packages/vue-apollo-ssr/src/index.ts
+++ b/packages/vue-apollo-ssr/src/index.ts
@@ -1,4 +1,4 @@
-import * as serializeJs from 'serialize-javascript'
+import serializeJs from 'serialize-javascript'
 import { ApolloClient } from '@apollo/client/core/index.js'
 
 export type ApolloClients = { [key: string]: ApolloClient<any> }

--- a/packages/vue-apollo-ssr/tsconfig.json
+++ b/packages/vue-apollo-ssr/tsconfig.json
@@ -5,7 +5,8 @@
     "moduleResolution": "node",
     "sourceMap": true,
     "skipLibCheck": true,
-    "strict": true
+    "strict": true,
+    "esModuleInterop": true
   },
   "include": [
     "src/**/*"


### PR DESCRIPTION
It fixess `serializeJs is not a function` error which appeared after upgrading `@vue/apollo-ssr` from `4.0.0-alpha.18` to `4.0.0-alpha.5` in a Nuxt 3 project.

Full error message:
```
[nuxt] [request error] [unhandled] [500] serializeJs is not a function
  at serializeStates (./.output/server/chunks/app/server.mjs:35:11)
  at ./.output/server/chunks/app/server.mjs:661:32
  at ./.output/server/chunks/app/server.mjs:107:44
  at fn (./.output/server/chunks/app/server.mjs:179:44)
  at Object.callAsync (./.output/server/node_modules/unctx/dist/index.mjs:68:55)
  at ./.output/server/chunks/app/server.mjs:181:56
  at Object.runWithContext (./.output/server/node_modules/@vue/runtime-core/dist/runtime-core.cjs.js:3855:18)
  at callWithNuxt (./.output/server/chunks/app/server.mjs:181:24)
  at Object.runWithContext (./.output/server/chunks/app/server.mjs:76:29)
  at contextCaller (./.output/server/chunks/app/server.mjs:107:23)
```

Reproduction of the issue: https://github.com/DawidKopys/apollo-ssr-serializejs-repro

First - to make ES module work - I had to use default import from `serialize-javascript` instead of the namespace import.
Then - to make the CJS module work and the tests to pass again - I turned on the `esModuleInterop` option in `tsconfig.ts`, so that it works with the default import.

[More info on the esModuleInterop ts option](https://www.typescriptlang.org/tsconfig#esModuleInterop)