### PR TITLE
fix: apollo components should have emits

### DIFF
--- a/packages/vue-apollo-components/src/ApolloMutation.js
+++ b/packages/vue-apollo-components/src/ApolloMutation.js
@@ -52,6 +52,8 @@ export default {
     }
   },
 
+  emits: [ 'loading', 'done', 'error' ],
+
   watch: {
     loading (value) {
       this.$emit('loading', value)

--- a/packages/vue-apollo-components/src/ApolloQuery.js
+++ b/packages/vue-apollo-components/src/ApolloQuery.js
@@ -15,6 +15,8 @@ export default {
     }
   },
 
+  emits: [ 'loading', 'result', 'error' ],
+
   props: {
     query: {
       type: [Function, Object],


### PR DESCRIPTION
Warnings appeared when the root tag is null.
![Screenshot 2023-08-22 131625](https://github.com/vuejs/apollo/assets/16623068/14435275-7013-44fa-a3f6-4e960a894c5e)
