### PR TITLE
docs: missing curly brace

### DIFF
--- a/packages/docs/src/guide-composable/subscription.md
+++ b/packages/docs/src/guide-composable/subscription.md
@@ -596,6 +596,7 @@ const wsLink = new WebSocketLink({
     connectionParams: {
         authToken: user.authToken,
     },
+  }
 })
 ```
 


### PR DESCRIPTION
Added the missing end curly brace in the object that's being passed into the WebSocketLink.