### PR TITLE
docs:  import createApolloProvider is missing

### DIFF
--- a/packages/docs/src/guide-components/setup.md
+++ b/packages/docs/src/guide-components/setup.md
@@ -37,6 +37,8 @@ Use the `@apollo/client/core` import path otherwise you will also import React.
 The provider holds the Apollo client instances that can then be used by all the child components.
 
 ```js
+import { createApolloProvider } from '@vue/apollo-option'
+
 const apolloProvider = createApolloProvider({
   defaultClient: apolloClient,
 })


### PR DESCRIPTION
I came across an issue recently related to createApolloProvider. However, after reviewing the documentation, I noticed its import was missing. Therefore, I took the initiative to add it myself, ensuring the issue was resolved promptly.