### PR TITLE
feat(useLazyQuery): add interface for lazy query return

### DIFF
--- a/packages/vue-apollo-composable/src/useLazyQuery.ts
+++ b/packages/vue-apollo-composable/src/useLazyQuery.ts
@@ -1,7 +1,7 @@
 import { DocumentNode } from 'graphql'
 import { isRef } from 'vue-demi'
 import { useQueryImpl, DocumentParameter, VariablesParameter, OptionsParameter, UseQueryOptions, UseQueryReturn } from './useQuery'
-import type { OperationVariables } from '@apollo/client/core/index.js'
+import type { OperationVariables } from '@apollo/client/core'
 
 export interface UseLazyQueryReturn<TResult, TVariables extends OperationVariables> extends UseQueryReturn<TResult, TVariables> {
   load: (document?: DocumentNode | null, variables?: TVariables | null, options?: UseQueryOptions | null) => false | Promise<TResult>

--- a/packages/vue-apollo-composable/src/useLazyQuery.ts
+++ b/packages/vue-apollo-composable/src/useLazyQuery.ts
@@ -1,6 +1,11 @@
 import { DocumentNode } from 'graphql'
 import { isRef } from 'vue-demi'
-import { useQueryImpl, DocumentParameter, VariablesParameter, OptionsParameter, UseQueryOptions } from './useQuery'
+import { useQueryImpl, DocumentParameter, VariablesParameter, OptionsParameter, UseQueryOptions, UseQueryReturn } from './useQuery'
+import type { OperationVariables } from '@apollo/client/core/index.js'
+
+export interface UseLazyQueryReturn<TResult, TVariables extends OperationVariables> extends UseQueryReturn<TResult, TVariables> {
+  load: (document?: DocumentNode | null, variables?: TVariables | null, options?: UseQueryOptions | null) => false | Promise<TResult>
+}
 
 export function useLazyQuery<
   TResult = any,
@@ -9,7 +14,7 @@ export function useLazyQuery<
   document: DocumentParameter<TResult, TVariables>,
   variables?: VariablesParameter<TVariables>,
   options?: OptionsParameter<TResult, TVariables>,
-) {
+): UseLazyQueryReturn<TResult, TVariables> {
   const query = useQueryImpl<TResult, TVariables>(document, variables, options, true)
 
   function load (


### PR DESCRIPTION
Currently result of `useQuery` have a type `UseQueryReturn`, but result of `useLazyQuery` [doesn't have any type defined](https://github.com/vuejs/apollo/blob/v4/packages/vue-apollo-composable/src/useLazyQuery.ts#L12)  

This merge request fixes this by adding new interface `UseLazyQueryReturn` which is extending interface `UseQueryReturn` with `load` method