### PR TITLE
fix: Add optional typescript peerDependency to apollo-composable package

### DIFF
--- a/packages/vue-apollo-composable/package.json
+++ b/packages/vue-apollo-composable/package.json
@@ -53,10 +53,14 @@
     "@apollo/client": "^3.4.13",
     "@vue/composition-api": "^1.0.0",
     "graphql": ">=15",
+    "typescript": ">=4.1.0",
     "vue": "^2.6.0 || ^3.1.0"
   },
   "peerDependenciesMeta": {
     "@vue/composition-api": {
+      "optional": true
+    },
+    "typescript": {
       "optional": true
     }
   },


### PR DESCRIPTION
Fixes #1499