### PR TITLE
test: fix subscription test

### DIFF
--- a/packages/test-e2e-composable-vue3/tests/e2e/specs/subscription.cy.ts
+++ b/packages/test-e2e-composable-vue3/tests/e2e/specs/subscription.cy.ts
@@ -9,6 +9,7 @@ describe('Subscription', () => {
     cy.get('input').type('Meow{enter}')
     cy.get('.message').should('have.length', 3)
     cy.get('.message').should('contain', 'Meow')
+    cy.get('input').should('have.value', '')
     cy.get('input').type('Waf{enter}')
     cy.get('.message').should('have.length', 6)
     cy.get('.message').should('contain', 'Waf')


### PR DESCRIPTION
**Cause (from video):** First character on second typing is ignored in github workflow, so it's "af" instead of "Waf"
**Idea:** Vue doesn't get to render the updated input before cypress tries to type again
**Fix strategy:** Check for input to be empty before typing again
