### PR TITLE
fix(useLazyQuery.ts): Export UseLazyQueryReturn from index.ts

### DIFF
--- a/packages/vue-apollo-composable/src/index.ts
+++ b/packages/vue-apollo-composable/src/index.ts
@@ -6,6 +6,7 @@ export {
 
 export {
   useLazyQuery,
+  UseLazyQueryReturn,
 } from './useLazyQuery'
 
 export {


### PR DESCRIPTION
Make import possible like
`import{ type UseLazyQueryReturn } from '@vue/apollo-composable`

instead of having to use which can lead to typescript errors.
`import { type UseLazyQueryReturn } from '@vue/apollo-composable/dist/useLazyQuery`
