### PR TITLE
fix: (@vue/apollo-option) memory leak in wrapped ssrRender

### DIFF
--- a/packages/vue-apollo-option/src/mixin.js
+++ b/packages/vue-apollo-option/src/mixin.js
@@ -115,11 +115,14 @@ export function installMixin (app, provider) {
       if (isServer) {
         // Patch render function to cleanup apollo
         const render = this.$options.ssrRender
+        if (!render) return
+        if (render.__IS_VUE_APOLLO_WRAPPED) return
         this.$options.ssrRender = (h) => {
           const result = render.call(this, h)
           destroy.call(this)
           return result
         }
+        this.$options.ssrRender.__IS_VUE_APOLLO_WRAPPED = true
       }
     },
 


### PR DESCRIPTION
Fixes https://github.com/vuejs/apollo/issues/1550

Two leaks were fixed:

1) Prevents repeatedly wrapping `ssrRender` by checking if it's already been wrapped. Added a `__IS_VUE_APOLLO_WRAPPED` boolean to track this. I verified that this was actually happening by throwing an error if it was already wrapped, and I observed the error.

2) `this.$options.ssrRender` doesn't always exist, but this.$apollo does. When the new wrapped `ssrRender` was called, it would throw, which prevented the `destroy.call(this)` line from running. The fix here was to not create a wrapped `ssrRender` if there isn't an original one.

---

❓ I don't know why a cleanup function like `destroy` is called inside of a render function. Usually I'd expect to see that happen from a conventional lifecycle hook, like `unmounted`. Maybe this wrapped `ssrRender` should not happen at all?