### PR TITLE
fix: remove generic package export

### DIFF
--- a/packages/vue-apollo-composable/package.json
+++ b/packages/vue-apollo-composable/package.json
@@ -30,8 +30,7 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.mjs",
       "require": "./dist/index.js"
-    },
-    "./*": "./*"
+    }
   },
   "files": [
     "dist"


### PR DESCRIPTION
I got the following error with nuxt:
```
[DEP0166] DeprecationWarning: Use of deprecated double slash resolving ".//index.mjs" for module request ".//index.mjs" matched to "./*" in the "exports" field module resolution of the package at D:\Programming\JabRefOnline\node_modules\@vue\apollo-composable\package.json
```
(I think this is windows specific)

This is fixed by removing the generic `./*` export field.