### PR TITLE
fix: augment `vue` rather than `@vue/runtime-core`

### DIFF
--- a/packages/vue-apollo-option/types/vue.d.ts
+++ b/packages/vue-apollo-option/types/vue.d.ts
@@ -2,7 +2,7 @@ import { DollarApollo } from './vue-apollo'
 import { VueApolloComponentOptions } from './options'
 import { ApolloProvider } from './apollo-provider'
 
-declare module '@vue/runtime-core' {
+declare module 'vue' {
   interface ComponentOptionsBase<
     Props,
     RawBindings,


### PR DESCRIPTION
This PR removes augmentations of `@vue/runtime-core` in favour of only augmenting `vue` (the new recommendation), which should fix issues when other packages are only augmenting vue (see nuxt/nuxt#28542).