### PR TITLE
fix: memory leak in SSR caused by global tracking

### DIFF
--- a/packages/vue-apollo-composable/src/util/loadingTracking.ts
+++ b/packages/vue-apollo-composable/src/util/loadingTracking.ts
@@ -27,6 +27,15 @@ export function getCurrentTracking () {
   }
 
   let tracking: LoadingTracking
+  if (isServer) {
+    // SSR does not support onScopeDispose, so if we don't skip this, it will leak memory
+    tracking = {
+      queries: ref(0),
+      mutations: ref(0),
+      subscriptions: ref(0),
+    }
+    return { tracking }
+  }
 
   if (!globalTracking.components.has(currentScope)) {
     // Add per-component tracking


### PR DESCRIPTION
Surprised that no one had noticed or reported this before. I even read comments by people on other websites mentioning a memory leak they encountered in vue-apollo, but no one ever elaborated or reported it apparently.

**onScopeDispose() does not work in SSR!** Thus this bit of logic that keeps Vue EffectScopes in a map never gets cleaned up and your memory will get filled up with them

https://github.com/vuejs/apollo/issues/1583