### PR TITLE
fix: useMutations onError Event hook gets triggered too early

### DIFF
--- a/packages/vue-apollo-composable/src/useMutation.ts
+++ b/packages/vue-apollo-composable/src/useMutation.ts
@@ -109,6 +109,7 @@ export function useMutation<
       const apolloError = toApolloError(e)
       error.value = apolloError
       loading.value = false
+      await nextTick()
       errorEvent.trigger(apolloError, {
         client,
       })


### PR DESCRIPTION
similar to #1558, except for onError