### PR TITLE
Fix link to V3 (Vue 2) documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 [![vue3](https://img.shields.io/badge/vue-3-brightgreen.svg)](https://vuejs.org/)
 ![GitHub branch check runs](https://img.shields.io/github/check-runs/vuejs/apollo/v4)
 
-:book: Documentation [**for Vue 3**](http://v4.apollo.vuejs.org) | [for Vue 2](https://apollo.vuejs.org/)
+:book: Documentation [**for Vue 3**](http://v4.apollo.vuejs.org) | [for Vue 2](https://v3.apollo.vuejs.org)
 
 [:pen: Contributing guide](./CONTRIBUTING.md)
 


### PR DESCRIPTION
Fix link to v3 (for Vue 2) documentation, as https://apollo.vuejs.org links to current documentation