### PR TITLE
docs: update outdated GraphQL mutations links

### DIFF
--- a/packages/docs/src/guide-composable/mutation.md
+++ b/packages/docs/src/guide-composable/mutation.md
@@ -1,6 +1,6 @@
 # Mutations
 
-Now that's we've learned [how to fetch data](./query), the next logical step is to study how to update data using **mutations**. If you need a refresher on mutations or GraphQL documents, read [this guide](https://graphql.org/learn/queries/#mutations).
+Now that's we've learned [how to fetch data](./query), the next logical step is to study how to update data using **mutations**. If you need a refresher on mutations or GraphQL documents, read [this guide](https://graphql.org/learn/mutations/).
 
 ## Executing a mutation
 

--- a/packages/docs/src/zh-cn/guide-composable/mutation.md
+++ b/packages/docs/src/zh-cn/guide-composable/mutation.md
@@ -1,6 +1,6 @@
 # 变更
 
-现在我们已经学习了[如何获取数据](./query)，下一步是学习如何使用**变更**来更新数据。如果你需要复习变更或 GraphQL 文档，请阅读[本指南](https://graphql.org/learn/queries/#mutations)。
+现在我们已经学习了[如何获取数据](./query)，下一步是学习如何使用**变更**来更新数据。如果你需要复习变更或 GraphQL 文档，请阅读[本指南](https://graphql.org/learn/mutations/)。
 
 ## 执行一个变更
 


### PR DESCRIPTION
Hi 👋
It seems some links to the **GraphQL mutations documentation** are outdated now, and the redirect doesn’t work properly. This ensures users land directly on the dedicated `/mutations` page.