### PR TITLE
fix: skipped SSR cache usage & precached data return

### DIFF
--- a/packages/vue-apollo-composable/src/useQuery.ts
+++ b/packages/vue-apollo-composable/src/useQuery.ts
@@ -286,10 +286,15 @@ export function useQueryImpl<
 
     // Make the cache data available to the component immediately
     // This prevents SSR hydration mismatches
-    if (!isServer && (firstStart || !currentOptions.value?.keepPreviousResult) && (currentOptions.value?.fetchPolicy !== 'no-cache' || currentOptions.value.notifyOnNetworkStatusChange)) {
+    if ((firstStart || !currentOptions.value?.keepPreviousResult) && (currentOptions.value?.fetchPolicy !== 'no-cache' || currentOptions.value.notifyOnNetworkStatusChange)) {
       const currentResult = query.value.getCurrentResult(false)
 
-      if (!currentResult.loading || currentResult.partial || currentOptions.value?.notifyOnNetworkStatusChange) {
+      // SSR: Allow reusing cached results
+      // CSR: Allow showing cached results immediately, but also show loading state if the query is currently loading and not showing partial data
+      const ssrCheck = isServer && currentOptions.value?.prefetch !== false && !currentResult.loading
+      const csrCheck = !isServer && (!currentResult.loading || currentResult.partial || currentOptions.value?.notifyOnNetworkStatusChange)
+
+      if (ssrCheck || csrCheck) {
         onNextResult(currentResult)
         ignoreNextResult = !currentResult.loading
       }

--- a/packages/vue-apollo-composable/src/useQuery.ts
+++ b/packages/vue-apollo-composable/src/useQuery.ts
@@ -280,11 +280,6 @@ export function useQueryImpl<
       query: currentDocument,
       variables: currentVariables ?? {} as TVariables,
       ...currentOptions.value,
-      ...(isServer && currentOptions.value?.fetchPolicy !== 'no-cache')
-        ? {
-            fetchPolicy: 'network-only',
-          }
-        : {},
     })
 
     startQuerySubscription()

--- a/packages/vue-apollo-option/src/smart-query.js
+++ b/packages/vue-apollo-option/src/smart-query.js
@@ -30,10 +30,6 @@ export default class SmartQuery extends SmartApollo {
       })
     }
 
-    if (isServer) {
-      this.options.fetchPolicy = 'network-only'
-    }
-
     if (!options.manual) {
       this.hasDataField = Object.prototype.hasOwnProperty.call(this.vm.$data, key)
       if (this.hasDataField) {


### PR DESCRIPTION
Two bugs:
- In SSR the fetchPolicy is always forced to be `network-only`? This makes no sense - what if you invoke the same exact operation from multiple places in the app? `network-only` is gonna skip cache and re-do the same exact request multiple times. Definitely not good, kinda crazy that this has been in the lib for so long.
- In SSR, waiting for results relies on `onServerPrefetch`, which is OK enough, but not enough for non-component use cases (e.g. Nuxt plugins/middlewares). Instead of just relying on onServerPrefetch, I made it also re-use the same logic CSR uses where if there's cached data already, it returns it immediately.