### PR TITLE
feat(useQuery): report retained results properly, add pending and

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,9 @@ jobs:
       - name: Lint
         run: pnpm run lint
 
+      - name: Typecheck
+        run: pnpm run typecheck
+
       - name: Build
         run: pnpm run build
 

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,6 @@ node_modules/
 dist/
 cache/
 .eslintcache
+*.tsbuildinfo
 coverage/
 packages/vue-apollo-composable/.api-reports

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "docs:build": "pnpm run build:packages-docs && pnpm run -r --filter \"private-vue-apollo-docs\" build",
     "lint": "eslint . --cache",
     "release": "pnpm run build && pnpm run test && sheep release -b v5 --tag next",
-    "test": "pnpm run -r --sequential test"
+    "test": "pnpm run -r --sequential test",
+    "typecheck": "pnpm run -r --filter \"vue-apollo*\" --filter \"@vue/apollo*\" typecheck"
   },
   "devDependencies": {
     "@akryum/sheep": "catalog:",

--- a/packages/docs/api/composable/@vue/namespaces/useLazyQuery/interfaces/Options.md
+++ b/packages/docs/api/composable/@vue/namespaces/useLazyQuery/interfaces/Options.md
@@ -165,6 +165,10 @@ Debounce variable updates (ms).
 
 Keep previous result while loading new data.
 
+The retained result is reported as a normal result — `resultState`, `result` and
+`partial` all describe it — with `isPreviousResult` set to `true` so it can be
+told apart from a fresh one.
+
 #### Default Value
 
 ```ts

--- a/packages/docs/api/composable/@vue/namespaces/useLazyQuery/interfaces/Result.md
+++ b/packages/docs/api/composable/@vue/namespaces/useLazyQuery/interfaces/Result.md
@@ -24,6 +24,16 @@ For more information, see [Handling operation errors](https://www.apollographql.
 
 ***
 
+### isPreviousResult
+
+> **isPreviousResult**: [`Ref`](https://vuejs.org/api/reactivity-core.html#ref)\<`boolean`\>
+
+If `true`, `result` was kept from the previous variables by the `keepPreviousResult` option, and does not correspond to the current `variables`.
+
+`resultState`, `result` and `partial` describe the retained result, so narrowing on `resultState` is always safe. `loading`, `networkStatus` and `error` describe the request that is replacing it.
+
+***
+
 ### result
 
 > **result**: [`Ref`](https://vuejs.org/api/reactivity-core.html#ref)\<`object` \| `null`\>
@@ -38,7 +48,9 @@ This value might be `undefined` if a query results in one or more errors (depend
 
 > **loading**: [`Ref`](https://vuejs.org/api/reactivity-core.html#ref)\<`boolean`\>
 
-If `true`, the query is still in flight.
+If `true`, the query is busy. That covers a request in flight, new variables waiting out the `debounce`/`throttle` timer, and the hand-over in between, where the variables have been accepted but the request has not gone out yet.
+
+Broader than `networkStatus < 7`, which describes only the request itself.
 
 ***
 
@@ -48,7 +60,19 @@ If `true`, the query is still in flight.
 
 A number indicating the current network state of the query's associated request. [See possible values.](https://github.com/apollographql/apollo-client/blob/d96f4578f89b933c281bb775a39503f6cdb59ee8/src/core/networkStatus.ts#L4)
 
+Describes the network only: it stays `ready` while `pending` is `true`.
+
 Used in conjunction with the [`notifyOnNetworkStatusChange`](./Options.md#notifyonnetworkstatuschange) option.
+
+***
+
+### pending
+
+> **pending**: [`Ref`](https://vuejs.org/api/reactivity-core.html#ref)\<`boolean`\>
+
+If `true`, `variables` have changed and a request is committed, but has not been issued yet because of the `debounce` or `throttle` option.
+
+`loading` covers this window as well; use `pending` to tell a timer that has not elapsed apart from a request that is actually on the wire.
 
 ## 3. Refs
 

--- a/packages/docs/api/composable/@vue/namespaces/useQuery/interfaces/Current.md
+++ b/packages/docs/api/composable/@vue/namespaces/useQuery/interfaces/Current.md
@@ -17,6 +17,16 @@ For more information, see [Handling operation errors](https://www.apollographql.
 
 ***
 
+### isPreviousResult
+
+> **isPreviousResult**: `boolean`
+
+If `true`, `result` was kept from the previous variables by the `keepPreviousResult` option, and does not correspond to the current `variables`.
+
+`resultState`, `result` and `partial` describe the retained result, so narrowing on `resultState` is always safe. `loading`, `networkStatus` and `error` describe the request that is replacing it.
+
+***
+
 ### ~~partial~~
 
 > **partial**: `boolean`
@@ -61,7 +71,11 @@ Describes the completeness of `result`.
 
 > **loading**: `boolean`
 
-If `true`, the query is still in flight.
+If `true`, the query is busy. That covers a request in flight, new variables
+waiting out the `debounce`/`throttle` timer, and the hand-over in between, where
+the variables have been accepted but the request has not gone out yet.
+
+Broader than `networkStatus < 7`, which describes only the request itself.
 
 ***
 
@@ -71,4 +85,16 @@ If `true`, the query is still in flight.
 
 A number indicating the current network state of the query's associated request. [See possible values.](https://github.com/apollographql/apollo-client/blob/d96f4578f89b933c281bb775a39503f6cdb59ee8/src/core/networkStatus.ts#L4)
 
+Describes the network only: it stays `ready` while `pending` is `true`.
+
 Used in conjunction with the [`notifyOnNetworkStatusChange`](./Options.md#notifyonnetworkstatuschange) option.
+
+***
+
+### pending
+
+> **pending**: `boolean`
+
+If `true`, `variables` have changed and a request is committed, but has not been issued yet because of the `debounce` or `throttle` option.
+
+`loading` covers this window as well; use `pending` to tell a timer that has not elapsed apart from a request that is actually on the wire.

--- a/packages/docs/api/composable/@vue/namespaces/useQuery/interfaces/Options.md
+++ b/packages/docs/api/composable/@vue/namespaces/useQuery/interfaces/Options.md
@@ -173,6 +173,10 @@ Reactive flag to enable/disable the query.
 
 Keep previous result while loading new data.
 
+The retained result is reported as a normal result — `resultState`, `result` and
+`partial` all describe it — with `isPreviousResult` set to `true` so it can be
+told apart from a fresh one.
+
 #### Default Value
 
 ```ts

--- a/packages/docs/api/composable/@vue/namespaces/useQuery/interfaces/Result.md
+++ b/packages/docs/api/composable/@vue/namespaces/useQuery/interfaces/Result.md
@@ -28,6 +28,16 @@ For more information, see [Handling operation errors](https://www.apollographql.
 
 ***
 
+### isPreviousResult
+
+> **isPreviousResult**: [`Ref`](https://vuejs.org/api/reactivity-core.html#ref)\<`boolean`\>
+
+If `true`, `result` was kept from the previous variables by the `keepPreviousResult` option, and does not correspond to the current `variables`.
+
+`resultState`, `result` and `partial` describe the retained result, so narrowing on `resultState` is always safe. `loading`, `networkStatus` and `error` describe the request that is replacing it.
+
+***
+
 ### result
 
 > **result**: [`Ref`](https://vuejs.org/api/reactivity-core.html#ref)\<`object` \| `null`\>
@@ -42,7 +52,9 @@ This value might be `undefined` if a query results in one or more errors (depend
 
 > **loading**: [`Ref`](https://vuejs.org/api/reactivity-core.html#ref)\<`boolean`\>
 
-If `true`, the query is still in flight.
+If `true`, the query is busy. That covers a request in flight, new variables waiting out the `debounce`/`throttle` timer, and the hand-over in between, where the variables have been accepted but the request has not gone out yet.
+
+Broader than `networkStatus < 7`, which describes only the request itself.
 
 ***
 
@@ -52,7 +64,19 @@ If `true`, the query is still in flight.
 
 A number indicating the current network state of the query's associated request. [See possible values.](https://github.com/apollographql/apollo-client/blob/d96f4578f89b933c281bb775a39503f6cdb59ee8/src/core/networkStatus.ts#L4)
 
+Describes the network only: it stays `ready` while `pending` is `true`.
+
 Used in conjunction with the [`notifyOnNetworkStatusChange`](./Options.md#notifyonnetworkstatuschange) option.
+
+***
+
+### pending
+
+> **pending**: [`Ref`](https://vuejs.org/api/reactivity-core.html#ref)\<`boolean`\>
+
+If `true`, `variables` have changed and a request is committed, but has not been issued yet because of the `debounce` or `throttle` option.
+
+`loading` covers this window as well; use `pending` to tell a timer that has not elapsed apart from a request that is actually on the wire.
 
 ## 3. Refs
 

--- a/packages/docs/data/queries.md
+++ b/packages/docs/data/queries.md
@@ -361,6 +361,65 @@ const { current } = useQuery(QUERY, {
 
 This pattern is useful for filters and pagination, where flashing an empty state on every change would be jarring.
 
+A retained result is reported as a normal result: `resultState`, `result` and `partial` all describe the data you are still showing, so narrowing on `resultState === 'complete'` keeps working. `isPreviousResult` tells the two apart, and `loading` describes the request that is on its way to replace it:
+
+```vue twoslash
+<script setup lang="ts">
+import { TypedDocumentNode } from '@apollo/client'
+import { useQuery } from '@vue/apollo-composable'
+import { ref } from 'vue'
+
+declare const gql: (literals: TemplateStringsArray, ...placeholders: any[]) => TypedDocumentNode<{ products: { id: string, name: string }[] }, { term: string }>
+const SearchProducts = gql``
+// ---cut---
+const term = ref('')
+
+const { current } = useQuery(SearchProducts, {
+  variables: { term },
+  keepPreviousResult: true,
+})
+</script>
+
+<template>
+  <ul v-if="current.resultState === 'complete'" :class="{ stale: current.isPreviousResult }">
+    <li v-for="product in current.result.products" :key="product.id">
+      {{ product.name }}
+    </li>
+  </ul>
+  <p v-else-if="!current.loading">
+    No products found.
+  </p>
+</template>
+```
+
+`resultState` describes the data being handed back; `loading`, `networkStatus` and `error` describe the request. Retention only ever changes the former.
+
+## Loading and the debounce window
+
+`loading` is `true` from the moment the query accepts new variables, not from the moment the request goes out. With `debounce` or `throttle`, that includes the window where the timer has not yet elapsed — so a search-as-you-type field shows a spinner on the keystroke rather than after the delay:
+
+```ts twoslash
+import { TypedDocumentNode } from '@apollo/client'
+import { useQuery } from '@vue/apollo-composable'
+import { ref } from 'vue'
+
+declare const gql: (literals: TemplateStringsArray, ...placeholders: any[]) => TypedDocumentNode<{ products: { id: string }[] }, { term: string }>
+const SearchProducts = gql``
+// ---cut---
+const term = ref('')
+
+const { loading, pending } = useQuery(SearchProducts, {
+  variables: { term },
+  debounce: 300,
+})
+// loading: true from the keystroke until the results land
+// pending: true only while the debounce timer is running
+```
+
+`pending` separates the two halves for the cases that need it (request metrics, cancel affordances). `networkStatus` describes the network alone and stays `ready` throughout the debounce window, so `loading` is deliberately broader than `networkStatus < 7`: it also spans the hand-over where the variables have been accepted but the request has not gone out yet.
+
+Variables that are rebuilt with deeply equal contents never report as pending, since no request will follow. Neither do variables that change and change back before the timer elapses.
+
 ## Awaiting the query
 
 `useQuery` returns a `PromiseLike` that resolves when initial data is available. Combined with `<Suspense>`, this gives you a server-rendered initial state and a unified loading fallback:

--- a/packages/vue-apollo-composable/package.json
+++ b/packages/vue-apollo-composable/package.json
@@ -46,7 +46,8 @@
     "coverage": "vitest run --coverage",
     "dev": "pnpm nodemon -w ./src -e ts -x pnpm build",
     "prepublishOnly": "pnpm run test && pnpm run build",
-    "test": "vitest run"
+    "test": "vitest run",
+    "typecheck": "tsc --build"
   },
   "peerDependencies": {
     "@apollo/client": "^4.1.0",

--- a/packages/vue-apollo-composable/src/compat/compat.test.ts
+++ b/packages/vue-apollo-composable/src/compat/compat.test.ts
@@ -328,8 +328,8 @@ describe('compat layer', () => {
         variables: { limit: 1, offset: 1 },
       })
 
-      expect(more?.data.paginatedTodos.items).toHaveLength(1)
-      expect(more?.data.paginatedTodos.items[0]?.text).toBe('Build Vue app')
+      expect(more?.data?.paginatedTodos.items).toHaveLength(1)
+      expect(more?.data?.paginatedTodos.items[0]?.text).toBe('Build Vue app')
 
       wrapper.unmount()
     })

--- a/packages/vue-apollo-composable/src/compat/useSubscription.ts
+++ b/packages/vue-apollo-composable/src/compat/useSubscription.ts
@@ -35,7 +35,7 @@ type DocumentParameter<TResult, TVariables> = MaybeRefOrGetter<DocumentNode | Ty
 type VariablesParameter<TVariables extends OperationVariables>
   = | MaybeRefOrGetter<TVariables>
     | { [Key in keyof TVariables]: MaybeRefOrGetter<TVariables[Key]> }
-type OptionsParameter<TResult, TVariables> = MaybeRefOrGetter<UseSubscriptionOptions<TResult, TVariables>>
+type OptionsParameter<TResult, TVariables extends OperationVariables> = MaybeRefOrGetter<UseSubscriptionOptions<TResult, TVariables>>
 
 /**
  * v4-style subscription result payload (`data` rather than v5's flatter `result.data`).
@@ -54,7 +54,7 @@ export interface OnErrorContext {
   client: ApolloClient
 }
 
-export interface UseSubscriptionReturn<TResult, TVariables> {
+export interface UseSubscriptionReturn<TResult, TVariables extends OperationVariables> {
   result: Readonly<Ref<TResult | undefined>>
   loading: Readonly<Ref<boolean>>
   error: Readonly<Ref<ErrorLike | null>>
@@ -74,13 +74,13 @@ export interface UseSubscriptionReturn<TResult, TVariables> {
 
 export function useSubscription<TResult = any>(
   document: DocumentParameter<TResult, undefined>,
-): UseSubscriptionReturn<TResult, undefined>
+): UseSubscriptionReturn<TResult, Record<string, never>>
 
 export function useSubscription<TResult = any>(
   document: DocumentParameter<TResult, undefined>,
   variables: undefined | null,
-  options: OptionsParameter<TResult, null>,
-): UseSubscriptionReturn<TResult, null>
+  options: OptionsParameter<TResult, Record<string, never>>,
+): UseSubscriptionReturn<TResult, Record<string, never>>
 
 export function useSubscription<TResult = any, TVariables extends OperationVariables = OperationVariables>(
   document: DocumentParameter<TResult, TVariables>,

--- a/packages/vue-apollo-composable/src/useLazyQuery.ts
+++ b/packages/vue-apollo-composable/src/useLazyQuery.ts
@@ -141,9 +141,11 @@ export function useLazyQuery<
     // Start the query
     queryResult.start()
 
-    // Wait for the query to complete or error
+    // Wait for the query to complete or error. A retained result belongs to the previous
+    // variables, so it does not count as having loaded.
     await until(() =>
-      queryResult.current.value.resultState === 'complete'
+      (queryResult.current.value.resultState === 'complete'
+        && !queryResult.current.value.isPreviousResult)
       || queryResult.current.value.error != null,
     ).toBe(true, { timeout: 30000 })
 

--- a/packages/vue-apollo-composable/src/useQuery.state.test.ts
+++ b/packages/vue-apollo-composable/src/useQuery.state.test.ts
@@ -1,0 +1,668 @@
+import type { TypedDocumentNode } from '@apollo/client'
+import type { EffectScope } from '@vue/reactivity'
+import { ApolloClient, ApolloLink, gql, InMemoryCache, NetworkStatus } from '@apollo/client'
+import { MockLink } from '@apollo/client/testing'
+import { effectScope, ref } from '@vue/reactivity'
+import { nextTick, watch } from '@vue/runtime-core'
+import { promiseTimeout, until } from '@vueuse/core'
+import { afterEach, assertType, describe, expect, it, vi } from 'vitest'
+import { provideApolloClient } from './useApolloClient.ts'
+import { useGlobalQueryLoading } from './useLoading.ts'
+import { useQuery } from './useQuery.ts'
+
+// #region Query
+interface Thing { __typename: 'Thing', id: string }
+interface ThingsData { things: Thing[] }
+interface ThingsVars { term: string }
+
+const THINGS_QUERY = gql`
+  query Things($term: String!) {
+    things(term: $term) {
+      id
+    }
+  }
+` as TypedDocumentNode<ThingsData, ThingsVars>
+// #endregion
+
+// #region Test harness
+const REQUEST_DELAY = 30
+
+function mock(term: string, ids: string[], options: { delay?: number, error?: Error } = {}) {
+  return {
+    request: { query: THINGS_QUERY, variables: { term } },
+    maxUsageCount: Number.POSITIVE_INFINITY,
+    delay: options.delay ?? REQUEST_DELAY,
+    ...(options.error
+      ? { error: options.error }
+      : { result: { data: { things: ids.map(id => ({ __typename: 'Thing', id })) } } }),
+  }
+}
+
+/** Apollo client backed by MockLink, with a counter for requests that reach the link. */
+function createMockClient(mocks: ReturnType<typeof mock>[]) {
+  const requests: string[] = []
+  const countLink = new ApolloLink((operation, forward) => {
+    requests.push(operation.variables.term as string)
+    return forward(operation)
+  })
+
+  const client = new ApolloClient({
+    link: ApolloLink.from([countLink, new MockLink(mocks, { showWarnings: false })]),
+    cache: new InMemoryCache(),
+  })
+
+  return { client, requests }
+}
+
+/** Flat snapshot of `current`, recorded on every state transition. */
+interface Snapshot {
+  resultState: string
+  ids: string[] | undefined
+  loading: boolean
+  pending: boolean
+  isPreviousResult: boolean
+  networkStatus: NetworkStatus
+  partial: boolean
+  error: string | undefined
+}
+
+const scopes: EffectScope[] = []
+
+/**
+ * `provideApolloClient()` is declared as returning `(fn) => any`, which would erase the
+ * query's types and silently defeat the narrowing assertions below. Annotate to keep them.
+ */
+type ThingsQuery = ReturnType<typeof useQuery<ThingsData, ThingsVars>>
+
+function createQuery(
+  client: ApolloClient,
+  options: () => useQuery.Options<ThingsData, ThingsVars>,
+) {
+  const scope = effectScope()
+  scopes.push(scope)
+
+  return scope.run(() => {
+    const query: ThingsQuery = provideApolloClient(client)(() => useQuery(THINGS_QUERY, options))
+
+    const transitions: Snapshot[] = []
+    watch(query.current, () => transitions.push(snapshot(query)), { flush: 'sync' })
+
+    return { query, transitions, globalLoading: useGlobalQueryLoading() }
+  })!
+}
+
+function snapshot(query: ThingsQuery): Snapshot {
+  const state = query.current.value
+  return {
+    resultState: state.resultState,
+    ids: state.result?.things.map(thing => thing.id),
+    loading: state.loading,
+    pending: state.pending,
+    isPreviousResult: state.isPreviousResult,
+    networkStatus: state.networkStatus,
+    partial: state.partial,
+    error: state.error?.message,
+  }
+}
+
+function ids(query: ThingsQuery) {
+  return query.current.value.result?.things.map(thing => thing.id)
+}
+
+function waitUntil(condition: () => boolean, timeout = 2000) {
+  return until(condition).toBe(true, { timeout, throwOnTimeout: true })
+}
+
+/** Resolves once the query has settled on a fresh (non-retained) complete result. */
+function waitForFresh(query: ThingsQuery) {
+  return waitUntil(() => query.current.value.resultState === 'complete'
+    && !query.current.value.isPreviousResult
+    && !query.current.value.loading)
+}
+
+afterEach(() => {
+  scopes.splice(0).forEach(scope => scope.stop())
+})
+// #endregion
+
+// #region Retention
+describe('useQuery keepPreviousResult', () => {
+  it('reports a coherent state while the previous result is retained', async () => {
+    const { client } = createMockClient([mock('a', ['a1']), mock('b', ['b1'])])
+    const term = ref('a')
+    const { query } = createQuery(client, () => ({
+      variables: { term: term.value },
+      fetchPolicy: 'no-cache',
+      keepPreviousResult: true,
+    }))
+
+    await waitForFresh(query)
+    expect(ids(query)).toEqual(['a1'])
+
+    term.value = 'b'
+    await nextTick()
+
+    // The retained rows are still there, and `resultState` says so.
+    expect(ids(query)).toEqual(['a1'])
+    expect(query.current.value.resultState).toBe('complete')
+    expect(query.current.value.isPreviousResult).toBe(true)
+    expect(query.current.value.loading).toBe(true)
+
+    await waitForFresh(query)
+    expect(ids(query)).toEqual(['b1'])
+    expect(query.current.value.isPreviousResult).toBe(false)
+  })
+
+  it('narrowing on resultState === "complete" keeps the retained result', async () => {
+    const { client } = createMockClient([mock('a', ['a1']), mock('b', ['b1'])])
+    const term = ref('a')
+    const { query } = createQuery(client, () => ({
+      variables: { term: term.value },
+      fetchPolicy: 'no-cache',
+      keepPreviousResult: true,
+    }))
+
+    await waitForFresh(query)
+    term.value = 'b'
+    await nextTick()
+
+    // The guard the union steers users toward must not discard the retained result.
+    const state = query.current.value
+    const rendered = state.resultState === 'complete' ? state.result.things.map(thing => thing.id) : null
+    expect(rendered).toEqual(['a1'])
+  })
+
+  it('moves result, resultState and partial together', async () => {
+    const { client } = createMockClient([mock('a', ['a1']), mock('b', ['b1'])])
+    const term = ref('a')
+    const { query } = createQuery(client, () => ({
+      variables: { term: term.value },
+      fetchPolicy: 'no-cache',
+      keepPreviousResult: true,
+    }))
+
+    await waitForFresh(query)
+    const before = {
+      result: query.current.value.result,
+      resultState: query.current.value.resultState,
+      partial: query.current.value.partial,
+    }
+
+    term.value = 'b'
+    await nextTick()
+
+    // The result-describing fields are retained as one unit.
+    expect({
+      result: query.current.value.result,
+      resultState: query.current.value.resultState,
+      partial: query.current.value.partial,
+    }).toEqual(before)
+  })
+
+  it('is false on the initial load, when there is nothing to retain', async () => {
+    const { client } = createMockClient([mock('a', ['a1'])])
+    const { query, transitions } = createQuery(client, () => ({
+      variables: { term: 'a' },
+      fetchPolicy: 'no-cache',
+      keepPreviousResult: true,
+    }))
+
+    await waitForFresh(query)
+    expect(transitions.every(t => t.isPreviousResult === false)).toBe(true)
+  })
+
+  it('does not retain when keepPreviousResult is not set', async () => {
+    const { client } = createMockClient([mock('a', ['a1']), mock('b', ['b1'])])
+    const term = ref('a')
+    const { query } = createQuery(client, () => ({
+      variables: { term: term.value },
+      fetchPolicy: 'no-cache',
+    }))
+
+    await waitForFresh(query)
+    term.value = 'b'
+    await nextTick()
+
+    expect(query.current.value.resultState).toBe('empty')
+    expect(query.current.value.result).toBeUndefined()
+    expect(query.current.value.isPreviousResult).toBe(false)
+  })
+
+  it('retains the previous result when the new request fails, and surfaces the error', async () => {
+    const { client } = createMockClient([
+      mock('a', ['a1']),
+      mock('b', [], { error: new Error('boom') }),
+    ])
+    const term = ref('a')
+    const { query } = createQuery(client, () => ({
+      variables: { term: term.value },
+      fetchPolicy: 'no-cache',
+      keepPreviousResult: true,
+    }))
+
+    await waitForFresh(query)
+    term.value = 'b'
+
+    await waitUntil(() => query.current.value.error != null)
+
+    expect(query.current.value.error?.message).toContain('boom')
+    expect(ids(query)).toEqual(['a1'])
+    expect(query.current.value.resultState).toBe('complete')
+    expect(query.current.value.isPreviousResult).toBe(true)
+  })
+
+  it('retains the previous result across enabled: false -> true', async () => {
+    const { client } = createMockClient([mock('a', ['a1'])])
+    const enabled = ref(true)
+    const { query } = createQuery(client, () => ({
+      variables: { term: 'a' },
+      fetchPolicy: 'no-cache',
+      keepPreviousResult: true,
+      enabled: enabled.value,
+    }))
+
+    await waitForFresh(query)
+    expect(ids(query)).toEqual(['a1'])
+
+    enabled.value = false
+    await nextTick()
+    expect(ids(query)).toEqual(['a1'])
+
+    enabled.value = true
+    await nextTick()
+
+    expect(ids(query)).toEqual(['a1'])
+    expect(query.current.value.resultState).toBe('complete')
+    expect(query.current.value.isPreviousResult).toBe(true)
+  })
+
+  it('does not fire result events for a retained state', async () => {
+    const { client } = createMockClient([mock('a', ['a1']), mock('b', ['b1'])])
+    const term = ref('a')
+    const { query } = createQuery(client, () => ({
+      variables: { term: term.value },
+      fetchPolicy: 'no-cache',
+      keepPreviousResult: true,
+    }))
+
+    const onResult = vi.fn()
+    const onCompleteResult = vi.fn()
+    query.onResult(onResult)
+    query.onCompleteResult(onCompleteResult)
+
+    await waitForFresh(query)
+    expect(onCompleteResult).toHaveBeenCalledTimes(1)
+
+    term.value = 'b'
+    await nextTick()
+
+    // No new result arrived - only a retained one.
+    expect(onResult).toHaveBeenCalledTimes(1)
+    expect(onCompleteResult).toHaveBeenCalledTimes(1)
+
+    await waitForFresh(query)
+    expect(onCompleteResult).toHaveBeenCalledTimes(2)
+  })
+
+  it('exposes isPreviousResult as a top-level ref that agrees with current', async () => {
+    const { client } = createMockClient([mock('a', ['a1']), mock('b', ['b1'])])
+    const term = ref('a')
+    const { query, transitions } = createQuery(client, () => ({
+      variables: { term: term.value },
+      fetchPolicy: 'no-cache',
+      keepPreviousResult: true,
+    }))
+
+    await waitForFresh(query)
+    term.value = 'b'
+    await nextTick()
+    expect(query.isPreviousResult.value).toBe(true)
+
+    await waitForFresh(query)
+    expect(query.isPreviousResult.value).toBe(false)
+    expect(transitions.some(t => t.isPreviousResult)).toBe(true)
+  })
+})
+// #endregion
+
+// #region Pending
+describe('useQuery pending state', () => {
+  it('reports pending and loading throughout the debounce window', async () => {
+    const { client, requests } = createMockClient([mock('a', ['a1']), mock('b', ['b1'])])
+    const term = ref('a')
+    const { query } = createQuery(client, () => ({
+      variables: { term: term.value },
+      fetchPolicy: 'no-cache',
+      keepPreviousResult: true,
+      debounce: 80,
+    }))
+
+    await waitForFresh(query)
+    expect(requests).toEqual(['a'])
+
+    term.value = 'b'
+    await nextTick()
+
+    // The user has typed and a fetch is committed, but nothing is on the wire yet.
+    expect(query.current.value.pending).toBe(true)
+    expect(query.current.value.loading).toBe(true)
+    expect(query.current.value.networkStatus).toBe(NetworkStatus.ready)
+    expect(requests).toEqual(['a'])
+    expect(ids(query)).toEqual(['a1'])
+
+    await waitForFresh(query)
+    expect(query.current.value.pending).toBe(false)
+    expect(requests).toEqual(['a', 'b'])
+    expect(ids(query)).toEqual(['b1'])
+  })
+
+  it('never drops loading between a variables change and the new result', async () => {
+    const { client } = createMockClient([mock('a', ['a1']), mock('b', ['b1'])])
+    const term = ref('a')
+    const { query, transitions } = createQuery(client, () => ({
+      variables: { term: term.value },
+      fetchPolicy: 'no-cache',
+      keepPreviousResult: true,
+      debounce: 80,
+    }))
+
+    await waitForFresh(query)
+    transitions.length = 0
+
+    term.value = 'b'
+    await waitForFresh(query)
+
+    // Every transition except the final one is part of the busy window.
+    const busyWindow = transitions.slice(0, -1)
+    expect(busyWindow.length).toBeGreaterThan(0)
+    expect(busyWindow.every(t => t.loading)).toBe(true)
+    expect(transitions.at(-1)?.loading).toBe(false)
+  })
+
+  it('keeps the loading ref and current.loading in agreement', async () => {
+    const { client } = createMockClient([mock('a', ['a1']), mock('b', ['b1'])])
+    const term = ref('a')
+    const { query } = createQuery(client, () => ({
+      variables: { term: term.value },
+      fetchPolicy: 'no-cache',
+      debounce: 80,
+    }))
+
+    const disagreements: string[] = []
+    watch(
+      () => [query.loading.value, query.current.value.loading, query.pending.value, query.current.value.pending] as const,
+      ([loadingRef, currentLoading, pendingRef, currentPending]) => {
+        if (loadingRef !== currentLoading || pendingRef !== currentPending) {
+          disagreements.push(`loading ${loadingRef}/${currentLoading} pending ${pendingRef}/${currentPending}`)
+        }
+      },
+      { flush: 'sync', immediate: true },
+    )
+
+    await waitForFresh(query)
+    term.value = 'b'
+    await waitForFresh(query)
+
+    expect(disagreements).toEqual([])
+  })
+
+  it('never reports pending without debounce or throttle', async () => {
+    const { client } = createMockClient([mock('a', ['a1']), mock('b', ['b1'])])
+    const term = ref('a')
+    const { query, transitions } = createQuery(client, () => ({
+      variables: { term: term.value },
+      fetchPolicy: 'no-cache',
+    }))
+
+    await waitForFresh(query)
+    term.value = 'b'
+    await waitForFresh(query)
+
+    expect(transitions.every(t => t.pending === false)).toBe(true)
+  })
+
+  it('does not report pending for a deeply-equal variables rebuild', async () => {
+    const { client, requests } = createMockClient([mock('a', ['a1'])])
+    const term = ref('a')
+    const { query, transitions } = createQuery(client, () => ({
+      variables: { term: term.value.trim() },
+      fetchPolicy: 'no-cache',
+      debounce: 80,
+    }))
+
+    await waitForFresh(query)
+    transitions.length = 0
+
+    // Deeply-equal rebuild: no fetch will follow, so there is nothing to be pending for.
+    term.value = 'a '
+    await nextTick()
+    expect(query.current.value.pending).toBe(false)
+    expect(query.current.value.loading).toBe(false)
+
+    await promiseTimeout(150)
+    expect(requests).toEqual(['a'])
+    expect(transitions.every(t => t.pending === false)).toBe(true)
+  })
+
+  it('does not issue a request for variables abandoned inside the debounce window', async () => {
+    const { client, requests } = createMockClient([mock('a', ['a1']), mock('b', ['b1'])])
+    const term = ref('a')
+    const { query } = createQuery(client, () => ({
+      variables: { term: term.value },
+      fetchPolicy: 'no-cache',
+      keepPreviousResult: true,
+      debounce: 80,
+    }))
+
+    await waitForFresh(query)
+
+    term.value = 'b'
+    await nextTick()
+    expect(query.current.value.pending).toBe(true)
+
+    term.value = 'a'
+    await nextTick()
+    expect(query.current.value.pending).toBe(false)
+    expect(query.current.value.loading).toBe(false)
+
+    await promiseTimeout(200)
+    expect(requests).toEqual(['a'])
+    expect(ids(query)).toEqual(['a1'])
+  })
+
+  it('commits immediately on the throttle leading edge, and reports pending on the trailing one', async () => {
+    const { client, requests } = createMockClient([
+      mock('a', ['a1']),
+      mock('b', ['b1']),
+      mock('c', ['c1']),
+    ])
+    const term = ref('a')
+    const { query } = createQuery(client, () => ({
+      variables: { term: term.value },
+      fetchPolicy: 'no-cache',
+      keepPreviousResult: true,
+      throttle: 120,
+    }))
+
+    await waitForFresh(query)
+
+    // Leading edge: committed straight away, so there is no pending window.
+    term.value = 'b'
+    await nextTick()
+    expect(query.current.value.pending).toBe(false)
+    expect(query.current.value.loading).toBe(true)
+
+    // Inside the throttle window: committed only on the trailing edge.
+    term.value = 'c'
+    await nextTick()
+    expect(query.current.value.pending).toBe(true)
+    expect(query.current.value.loading).toBe(true)
+
+    await waitForFresh(query)
+    expect(requests).toEqual(['a', 'b', 'c'])
+    expect(ids(query)).toEqual(['c1'])
+  })
+
+  it('counts the debounce window as loading in the global loading tracker', async () => {
+    const { client } = createMockClient([mock('a', ['a1']), mock('b', ['b1'])])
+    const term = ref('a')
+    const { query, globalLoading } = createQuery(client, () => ({
+      variables: { term: term.value },
+      fetchPolicy: 'no-cache',
+      debounce: 80,
+    }))
+
+    await waitForFresh(query)
+    await waitUntil(() => globalLoading.value === false)
+
+    term.value = 'b'
+    await nextTick()
+    expect(globalLoading.value).toBe(true)
+
+    await waitForFresh(query)
+    await waitUntil(() => globalLoading.value === false)
+  })
+})
+// #endregion
+
+// #region Awaiting
+describe('useQuery awaiting with a retained result', () => {
+  it('does not resolve against a retained result', async () => {
+    const { client } = createMockClient([mock('a', ['a1']), mock('b', ['b1'])])
+    const term = ref('a')
+    const { query } = createQuery(client, () => ({
+      variables: { term: term.value },
+      fetchPolicy: 'no-cache',
+      keepPreviousResult: true,
+    }))
+
+    await query
+    expect(ids(query)).toEqual(['a1'])
+
+    term.value = 'b'
+    await nextTick()
+    expect(query.current.value.isPreviousResult).toBe(true)
+
+    // `await` must wait for the data it was asked for, not the rows left on screen.
+    await query
+    expect(query.current.value.isPreviousResult).toBe(false)
+    expect(ids(query)).toEqual(['b1'])
+  })
+
+  it('rejects when the request replacing a retained result fails', async () => {
+    const { client } = createMockClient([
+      mock('a', ['a1']),
+      mock('b', [], { error: new Error('boom') }),
+    ])
+    const term = ref('a')
+    const { query } = createQuery(client, () => ({
+      variables: { term: term.value },
+      fetchPolicy: 'no-cache',
+      keepPreviousResult: true,
+    }))
+
+    await query
+    term.value = 'b'
+
+    // The retained result never becomes fresh, so awaiting has to settle on the error.
+    const outcome = await Promise.race([
+      (async () => {
+        try {
+          await query
+          return 'resolved'
+        }
+        catch (error) {
+          return (error as Error).message
+        }
+      })(),
+      promiseTimeout(1000).then(() => 'HUNG'),
+    ])
+
+    expect(outcome).toContain('boom')
+  })
+})
+// #endregion
+
+// #region Variable commits
+describe('useQuery variable commits', () => {
+  it('issues one request per settled variables change', async () => {
+    const { client, requests } = createMockClient([
+      mock('a1', ['first']),
+      mock('b1', ['intermediate']),
+      mock('b2', ['final']),
+    ])
+    const filter = ref('a')
+    const page = ref(1)
+    const { query } = createQuery(client, () => ({
+      variables: { term: `${filter.value}${page.value}` },
+      fetchPolicy: 'no-cache',
+    }))
+
+    await waitForFresh(query)
+    expect(requests).toEqual(['a1'])
+
+    // Two writes in one tick are one intended change; the intermediate must not be sent.
+    filter.value = 'b'
+    page.value = 2
+
+    await waitForFresh(query)
+    expect(requests).toEqual(['a1', 'b2'])
+    expect(ids(query)).toEqual(['final'])
+  })
+
+  it('does not emit consecutive identical states from onNextState', async () => {
+    const { client } = createMockClient([mock('a', ['a1']), mock('b', ['b1'])])
+    const term = ref('a')
+    const { query } = createQuery(client, () => ({
+      variables: { term: term.value },
+      fetchPolicy: 'no-cache',
+      keepPreviousResult: true,
+    }))
+
+    const emitted: string[] = []
+    query.onNextState((state) => {
+      emitted.push([
+        state.resultState,
+        state.result?.things.map(thing => thing.id).join(','),
+        state.loading,
+        state.pending,
+        state.isPreviousResult,
+        state.networkStatus,
+      ].join('|'))
+    })
+
+    await waitForFresh(query)
+    term.value = 'b'
+    await waitForFresh(query)
+
+    const duplicates = emitted.filter((entry, index) => index > 0 && entry === emitted[index - 1])
+    expect(duplicates).toEqual([])
+  })
+})
+// #endregion
+
+// #region Types
+describe('useQuery state types', () => {
+  it('types the new state fields', () => {
+    const { client } = createMockClient([mock('a', ['a1'])])
+    const { query } = createQuery(client, () => ({
+      variables: { term: 'a' },
+      fetchPolicy: 'no-cache',
+      keepPreviousResult: true,
+    }))
+
+    assertType<boolean>(query.current.value.pending)
+    assertType<boolean>(query.current.value.isPreviousResult)
+    assertType<boolean>(query.current.value.loading)
+    assertType<boolean>(query.pending.value)
+    assertType<boolean>(query.isPreviousResult.value)
+
+    const state = query.current.value
+    if (state.resultState === 'complete') {
+      assertType<ThingsData>(state.result)
+    }
+
+    expect(true).toBe(true)
+  })
+})
+// #endregion

--- a/packages/vue-apollo-composable/src/useQuery.test.ts
+++ b/packages/vue-apollo-composable/src/useQuery.test.ts
@@ -1,6 +1,6 @@
 import type { DocumentNode, TypedDocumentNode } from '@apollo/client'
 import { gql, NetworkStatus } from '@apollo/client'
-import { computed, reactive, ref } from '@vue/reactivity'
+import { computed, effectScope, reactive, ref } from '@vue/reactivity'
 import { defineComponent, h, nextTick, Suspense } from '@vue/runtime-core'
 import { createSSRApp } from '@vue/runtime-dom'
 import { renderToString } from '@vue/server-renderer'
@@ -9,7 +9,7 @@ import { promiseTimeout, until } from '@vueuse/core'
 import { afterAll, afterEach, assertType, beforeAll, describe, expect, it, vi } from 'vitest'
 import { createApolloClient } from './test-utils/client.ts'
 import { startServer, stopServer } from './test-utils/server.ts'
-import { DefaultApolloClient } from './useApolloClient.ts'
+import { DefaultApolloClient, provideApolloClient } from './useApolloClient.ts'
 import { useGlobalQueryLoading, useQueryLoading } from './useLoading.ts'
 import { useQuery } from './useQuery.ts'
 
@@ -82,6 +82,15 @@ const DEFER_QUERY = gql`
     hello
     ... @defer {
       slow(delay: 1000)
+    }
+  }
+` as TypedDocumentNode<{ hello: string, slow?: string }, {}>
+
+const DEFER_FAST_QUERY = gql`
+  query DeferFastQuery {
+    hello
+    ... @defer {
+      slow(delay: 150)
     }
   }
 ` as TypedDocumentNode<{ hello: string, slow?: string }, {}>
@@ -1112,15 +1121,20 @@ describe('useQuery', () => {
 
     await until(() => wrapper.vm.current.resultState).toBe('complete', { timeout: 200 })
     expect(wrapper.find('div').text()).toBe('first')
+    expect(wrapper.vm.current.isPreviousResult).toBe(false)
 
     // Change variables - should keep previous result while loading
     wrapper.vm.message = 'second'
     await nextTick()
 
-    // Result should still be 'first' while loading
+    // Result should still be 'first' while loading, reported as a retained result rather
+    // than as an empty one.
     expect(wrapper.vm.result?.echo).toBe('first')
+    expect(wrapper.vm.current.resultState).toBe('complete')
+    expect(wrapper.vm.current.isPreviousResult).toBe(true)
+    expect(wrapper.vm.current.loading).toBe(true)
 
-    await until(() => wrapper.vm.current.resultState).toBe('complete', { timeout: 200 })
+    await until(() => wrapper.vm.current.isPreviousResult).toBe(false, { timeout: 200 })
     expect(wrapper.find('div').text()).toBe('second')
 
     wrapper.unmount()
@@ -1654,6 +1668,34 @@ describe('useQuery', () => {
     const html = await renderToString(app)
     expect(html).toContain('world')
     expect(html).toContain('class="data"')
+  })
+  // #endregion
+
+  // #region awaitComplete
+  it('should resolve on the first non-empty state by default', async () => {
+    const scope = effectScope()
+    const query = scope.run(() =>
+      provideApolloClient(apolloClient)(() => useQuery(DEFER_FAST_QUERY)),
+    )!
+
+    await query
+    expect(query.current.value.resultState).toBe('streaming')
+    expect(query.result.value?.slow).toBeUndefined()
+
+    scope.stop()
+  })
+
+  it('awaitComplete should wait for the deferred data', async () => {
+    const scope = effectScope()
+    const query = scope.run(() =>
+      provideApolloClient(apolloClient)(() => useQuery(DEFER_FAST_QUERY, { awaitComplete: true })),
+    )!
+
+    await query
+    expect(query.current.value.resultState).toBe('complete')
+    expect(query.result.value?.slow).toBe('done')
+
+    scope.stop()
   })
   // #endregion
 

--- a/packages/vue-apollo-composable/src/useQuery.ts
+++ b/packages/vue-apollo-composable/src/useQuery.ts
@@ -106,6 +106,10 @@ export declare namespace useQuery {
       /**
        * Keep previous result while loading new data.
        *
+       * The retained result is reported as a normal result — `resultState`, `result` and
+       * `partial` all describe it — with `isPreviousResult` set to `true` so it can be
+       * told apart from a fresh one.
+       *
        * @defaultValue false
        * @group 4. Vue-Apollo
        */
@@ -237,11 +241,47 @@ export declare namespace useQuery {
     TVariables extends OperationVariables = OperationVariables,
   > = Options<TData, TVariables> | DisabledOptions<TData, TVariables>
 
+  /**
+   * Apollo's query result with Vue-Apollo naming: `result`/`resultState` instead of
+   * `data`/`dataState`. This is the state as Apollo reports it, before Vue-Apollo layers
+   * {@link VueApolloState} on top.
+   */
+  export type ResultState<
+    TData,
+    TStates extends DataState<TData>['dataState'] = DataState<TData>['dataState'],
+  > = RenameKey<RenameKey<ObservableQuery.Result<TData, TStates>, 'dataState', 'resultState'>, 'data', 'result'>
+
+  /** State tracked by Vue-Apollo itself, on top of what Apollo reports. */
+  export interface VueApolloState {
+    /**
+     * If `true`, `variables` have changed and a request is committed, but has not been
+     * issued yet because of the `debounce` or `throttle` option.
+     *
+     * `loading` covers this window as well; use `pending` to tell a timer that has not
+     * elapsed apart from a request that is actually on the wire.
+     *
+     * @group 2. Network info
+     */
+    pending: boolean
+
+    /**
+     * If `true`, `result` was kept from the previous variables by the `keepPreviousResult`
+     * option, and does not correspond to the current `variables`.
+     *
+     * `resultState`, `result` and `partial` describe the retained result, so narrowing on
+     * `resultState` is always safe. `loading`, `networkStatus` and `error` describe the
+     * request that is replacing it.
+     *
+     * @group 1. Operation data
+     */
+    isPreviousResult: boolean
+  }
+
   /** Query result with Vue-Apollo naming: `result`/`resultState` instead of `data`/`dataState`. */
   export type Current<
     TData,
     TStates extends DataState<TData>['dataState'] = DataState<TData>['dataState'],
-  > = RenameKey<RenameKey<ObservableQuery.Result<TData, TStates>, 'dataState', 'resultState'>, 'data', 'result'>
+  > = ResultState<TData, TStates> & VueApolloState
 
   /** FetchMore result with Vue-Apollo naming: `result` instead of `data`. */
   export type FetchMoreResult<TData> = RenameKey<ApolloClient.QueryResult<MaybeMasked<TData>>, 'data', 'result'>
@@ -254,14 +294,30 @@ export declare namespace useQuery {
     > {
 
       /**
-       * If `true`, the query is still in flight.
+       * If `true`, the query is busy. That covers a request in flight, new variables
+       * waiting out the `debounce`/`throttle` timer, and the hand-over in between, where
+       * the variables have been accepted but the request has not gone out yet.
+       *
+       * Broader than `networkStatus < 7`, which describes only the request itself.
        *
        * @group 2. Network info
        */
       loading: Readonly<Ref<boolean>>
 
       /**
+       * {@inheritDoc @vue/apollo-composable!useQuery.VueApolloState#pending:member}
+       */
+      pending: Readonly<Ref<boolean>>
+
+      /**
+       * {@inheritDoc @vue/apollo-composable!useQuery.VueApolloState#isPreviousResult:member}
+       */
+      isPreviousResult: Readonly<Ref<boolean>>
+
+      /**
        * A number indicating the current network state of the query's associated request. [See possible values.](https://github.com/apollographql/apollo-client/blob/d96f4578f89b933c281bb775a39503f6cdb59ee8/src/core/networkStatus.ts#L4)
+       *
+       * Describes the network only: it stays `ready` while `pending` is `true`.
        *
        * Used in conjunction with the [`notifyOnNetworkStatusChange`](./Options.md#notifyonnetworkstatuschange) option.
        *
@@ -613,14 +669,26 @@ export declare namespace useQuery {
         resultState: 'empty' | 'complete' | 'streaming' | 'partial'
 
         /**
-         * If `true`, the query is still in flight.
+         * If `true`, the query is busy. That covers a request in flight, new variables
+         * waiting out the `debounce`/`throttle` timer, and the hand-over in between, where
+         * the variables have been accepted but the request has not gone out yet.
+         *
+         * Broader than `networkStatus < 7`, which describes only the request itself.
          *
          * @group 2. Network info
          */
         loading: boolean
 
+        /** {@inheritDoc @vue/apollo-composable!useQuery.VueApolloState#pending:member} */
+        pending: boolean
+
+        /** {@inheritDoc @vue/apollo-composable!useQuery.VueApolloState#isPreviousResult:member} */
+        isPreviousResult: boolean
+
         /**
          * A number indicating the current network state of the query's associated request. [See possible values.](https://github.com/apollographql/apollo-client/blob/d96f4578f89b933c281bb775a39503f6cdb59ee8/src/core/networkStatus.ts#L4)
+         *
+         * Describes the network only: it stays `ready` while `pending` is `true`.
          *
          * Used in conjunction with the [`notifyOnNetworkStatusChange`](./Options.md#notifyonnetworkstatuschange) option.
          *
@@ -781,6 +849,12 @@ export declare namespace useQuery {
         /** {@inheritDoc @vue/apollo-composable!useQuery.Base.Result#loading:member} */
         loading: Ref<boolean>
 
+        /** {@inheritDoc @vue/apollo-composable!useQuery.VueApolloState#pending:member} */
+        pending: Ref<boolean>
+
+        /** {@inheritDoc @vue/apollo-composable!useQuery.VueApolloState#isPreviousResult:member} */
+        isPreviousResult: Ref<boolean>
+
         /** {@inheritDoc @vue/apollo-composable!useQuery.Base.Result#networkStatus:member} */
         networkStatus: Ref<NetworkStatus>
 
@@ -849,18 +923,30 @@ function shouldReobserve<TData, TVariables extends OperationVariables>(
   )
 }
 
-function toCurrent<
+function toResultState<
   TData,
   TStates extends
   DataState<TData>['dataState'] = DataState<TData>['dataState'],
->(result: ObservableQuery.Result<TData, TStates>): useQuery.Current<TData, TStates> {
+>(result: ObservableQuery.Result<TData, TStates>): useQuery.ResultState<TData, TStates> {
   const { data, dataState, ...rest } = result
 
   return {
     result: data,
     resultState: dataState,
     ...rest,
-  } as useQuery.Current<TData, TStates>
+  } as useQuery.ResultState<TData, TStates>
+}
+
+/**
+ * Compares every key rather than a fixed list, so a field Apollo adds to its result cannot
+ * flow through `toResultState`'s spread and be silently swallowed. `result` is compared by
+ * identity: retaining reuses the object, a new result never does.
+ */
+function isSameState<TData>(a: useQuery.Current<TData>, b: useQuery.Current<TData>) {
+  const keys = Object.keys(a) as Array<keyof useQuery.Current<TData>>
+
+  return keys.length === Object.keys(b).length
+    && keys.every(key => a[key] === b[key])
 }
 
 function toFetchMoreResult<TData>(result: ApolloClient.QueryResult<TData>): useQuery.FetchMoreResult<TData> {
@@ -922,6 +1008,7 @@ export function useQueryImpl<
       debounce,
       prefetch,
       keepPreviousResult,
+      awaitComplete,
     } = options.value ?? {}
 
     return {
@@ -931,6 +1018,7 @@ export function useQueryImpl<
       debounce,
       prefetch,
       keepPreviousResult,
+      awaitComplete,
     } as useQuery.Base.VueApolloOptions
   })
   // #endregion
@@ -976,14 +1064,42 @@ export function useQueryImpl<
   /** The actual variables sent to Apollo (may be delayed by debounce/throttle) */
   const currentVariables = shallowRef(variables.value)
 
-  const setDebouncedVariables = useDebounceFn((newVariables: TVariables) => {
+  /**
+   * `true` while `variables` have moved ahead of what has actually been handed to Apollo,
+   * which is exactly the `debounce`/`throttle` window.
+   */
+  const pending = computed(() => {
+    const { debounce, throttle } = vueApolloQueryOptions.value
+    if (debounce == null && throttle == null) {
+      return false
+    }
+    return !equal(variables.value, currentVariables.value)
+  })
+
+  /**
+   * Bridges the gap between `pending` clearing (on write) and `loading` being set on the
+   * next flush, when the watcher below reobserves.
+   */
+  const isCommitting = ref(false)
+
+  function commitVariables(newVariables: TVariables) {
+    if (equal(newVariables, currentVariables.value)) {
+      // No request will follow, so there is nothing to stay busy for.
+      currentVariables.value = newVariables
+      return
+    }
+
+    isCommitting.value = true
     currentVariables.value = newVariables
-  }, () => vueApolloQueryOptions.value.debounce ?? 0)
+  }
+
+  const setDebouncedVariables = useDebounceFn(
+    commitVariables,
+    () => vueApolloQueryOptions.value.debounce ?? 0,
+  )
 
   const setThrottledVariables = useThrottleFn(
-    (newVariables: TVariables) => {
-      currentVariables.value = newVariables
-    },
+    commitVariables,
     () => vueApolloQueryOptions.value.throttle ?? 0,
     true, // trailing edge
   )
@@ -997,7 +1113,7 @@ export function useQueryImpl<
       setThrottledVariables(newVariables)
     }
     else {
-      currentVariables.value = newVariables
+      commitVariables(newVariables)
     }
   }, { flush: 'sync' })
   // #endregion
@@ -1009,19 +1125,75 @@ export function useQueryImpl<
   const observableQuery = shallowRef<ObservableQuery<TData, TVariables>>()
   const subscription = shallowRef<Subscription>()
 
-  const currentState = shallowRef<useQuery.Current<TData>>({
+  /**
+   * `isPreviousResult` lives in here rather than its own ref so committing a state is a
+   * single write, and no watcher can catch a fresh result still flagged as retained.
+   */
+  const currentState = shallowRef<useQuery.ResultState<TData> & Pick<useQuery.VueApolloState, 'isPreviousResult'>>({
     result: undefined,
     loading: false,
     networkStatus: NetworkStatus.ready,
     resultState: 'empty',
     partial: false,
+    isPreviousResult: false,
   })
+
+  /**
+   * Retains the previous result when `keepPreviousResult` is on and the incoming state has
+   * none. `result`/`resultState`/`partial` move together so the union stays truthful;
+   * `loading`/`networkStatus`/`error` always come from the incoming state.
+   */
+  function applyState(newState: useQuery.ResultState<TData>) {
+    const previousState = currentState.value
+
+    if (
+      newState.resultState === 'empty'
+      && vueApolloQueryOptions.value.keepPreviousResult
+      && previousState.resultState !== 'empty'
+    ) {
+      const { error: _previousError, ...retainedResult } = previousState
+
+      currentState.value = {
+        ...retainedResult,
+        ...(newState.error !== undefined && { error: newState.error }),
+        loading: newState.loading,
+        networkStatus: newState.networkStatus,
+        isPreviousResult: true,
+      }
+      return
+    }
+
+    currentState.value = { ...newState, isPreviousResult: false }
+  }
 
   // Computed refs for public API - defined early so trackQuery can be called before query starts
   const result = computed(() => currentState.value.result)
-  const loading = computed(() => currentState.value.loading)
   const networkStatus = computed(() => currentState.value.networkStatus)
   const error = computed(() => currentState.value.error)
+  const isPreviousResult = computed(() => currentState.value.isPreviousResult)
+
+  /** Busy from the moment new variables are accepted, not when the request goes out. */
+  const loading = computed(() => pending.value || isCommitting.value || currentState.value.loading)
+
+  /**
+   * Returns the previous object when nothing actually changed, so `watch(current)` and
+   * `onNextState` do not report a change that is not one.
+   */
+  let lastCurrent: useQuery.Current<TData> | undefined
+  const current = computed<useQuery.Current<TData>>(() => {
+    const newCurrent = {
+      ...currentState.value,
+      loading: loading.value,
+      pending: pending.value,
+    }
+
+    if (lastCurrent !== undefined && isSameState(lastCurrent, newCurrent)) {
+      return lastCurrent
+    }
+
+    lastCurrent = newCurrent
+    return newCurrent
+  })
 
   if (currentScope)
     trackQuery(loading)
@@ -1035,30 +1207,17 @@ export function useQueryImpl<
   const streamingResultEvent = createEventHook<unknown>()
   const errorEvent = createEventHook<ErrorLike>()
 
-  // Event handlers - trigger specific events based on state
-  nextStateEvent.on((newState) => {
-    // When keepPreviousResult is true and new state has no result,
-    // preserve the previous result while still updating loading/networkStatus/resultState
-    if (
-      newState.resultState === 'empty'
-      && vueApolloQueryOptions.value.keepPreviousResult
-      && currentState.value.result != null
-    ) {
-      currentState.value = {
-        ...newState,
-        result: currentState.value.result,
-      } as unknown as useQuery.Current<TData>
-    }
-    else {
-      currentState.value = newState
-    }
+  // Mirrors the public state, so it also fires for the debounce/throttle window.
+  watch(current, (newCurrent) => {
+    void nextStateEvent.trigger(newCurrent)
+  }, { flush: 'sync' })
 
-    // Trigger error event
+  /** Keyed off the incoming state: a retained result is not a new result. */
+  function triggerResultEvents(newState: useQuery.ResultState<TData>) {
     if (newState.error) {
       errorEvent.trigger(newState.error)
     }
 
-    // Trigger result events based on resultState
     if (newState.resultState === 'complete') {
       completeResultEvent.trigger(newState.result)
       resultEvent.trigger(newState.result)
@@ -1071,7 +1230,7 @@ export function useQueryImpl<
       streamingResultEvent.trigger(newState.result)
       resultEvent.trigger(newState.result)
     }
-  })
+  }
   // #endregion
 
   // #region Observable Query
@@ -1095,9 +1254,12 @@ export function useQueryImpl<
       }
 
       if (newObservableQuery) {
-        currentState.value = toCurrent(newObservableQuery.getCurrentResult())
+        // Via applyState so a query toggled off and back on keeps its previous result.
+        applyState(toResultState(newObservableQuery.getCurrentResult()))
         subscription.value = newObservableQuery.subscribe((newState) => {
-          nextStateEvent.trigger(toCurrent(newState))
+          const nextState = toResultState(newState)
+          applyState(nextState)
+          triggerResultEvents(nextState)
         })
       }
     },
@@ -1115,27 +1277,36 @@ export function useQueryImpl<
     }
   }, { immediate: true, flush: 'sync' })
 
-  /** React to option changes - reobserve or apply new options as needed */
+  /**
+   * React to option changes - reobserve or apply new options as needed.
+   *
+   * Kept on the default `pre` flush so writes in the same tick coalesce into one request.
+   */
   watch(apolloWatchQueryOptions, (newOptions, oldOptions) => {
-    if (observableQuery.value == null) {
-      return
-    }
+    try {
+      if (observableQuery.value == null) {
+        return
+      }
 
-    if (
-      shouldReobserve(
-        oldOptions as Readonly<ApolloClient.WatchQueryOptions<unknown, OperationVariables>>,
-        newOptions as Readonly<ApolloClient.WatchQueryOptions<unknown, OperationVariables>>,
-      )
-    ) {
-      observableQuery.value?.reobserve(newOptions)
-    }
-    else {
-      observableQuery.value?.applyOptions(newOptions)
-    }
+      if (
+        shouldReobserve(
+          oldOptions as Readonly<ApolloClient.WatchQueryOptions<unknown, OperationVariables>>,
+          newOptions as Readonly<ApolloClient.WatchQueryOptions<unknown, OperationVariables>>,
+        )
+      ) {
+        observableQuery.value?.reobserve(newOptions)
+      }
+      else {
+        observableQuery.value?.applyOptions(newOptions)
+      }
 
-    const newCurrent = toCurrent(observableQuery.value.getCurrentResult())
-    if (newCurrent.resultState === 'empty' && !vueApolloQueryOptions.value.keepPreviousResult) {
-      currentState.value = newCurrent
+      const newState = toResultState(observableQuery.value.getCurrentResult())
+      if (newState.resultState === 'empty') {
+        applyState(newState)
+      }
+    }
+    finally {
+      isCommitting.value = false
     }
   })
   // #endregion
@@ -1202,9 +1373,11 @@ export function useQueryImpl<
   }
 
   const response = {
-    current: currentState,
+    current,
     result,
     loading,
+    pending,
+    isPreviousResult,
     networkStatus,
     error,
 
@@ -1229,15 +1402,30 @@ export function useQueryImpl<
     onError: errorEvent.on,
   } as useQuery.Result<TData, TVariables>
 
+  /**
+   * A retained result belongs to the previous variables, so awaiting must wait past it for
+   * the data that was actually asked for.
+   */
+  function isAwaited(state: useQuery.Current<TData>) {
+    // Settle on an error only once nothing more is coming, so a mid-stream error does not
+    // pre-empt `awaitComplete`. Without this a failed replacement for a retained result
+    // never reaches a fresh state and the await hangs.
+    if (state.error != null && !state.loading) {
+      return true
+    }
+    if (state.isPreviousResult) {
+      return false
+    }
+    return vueApolloQueryOptions.value.awaitComplete
+      ? state.resultState === 'complete'
+      : state.resultState !== 'empty'
+  }
+
   function then(
     onfulfilled?: ((value: useQuery.Result<TData, TVariables>) => void | PromiseLike<void>),
     onrejected?: ((reason: any) => void | PromiseLike<void>),
   ): PromiseLike<any> {
-    if (
-      vueApolloQueryOptions.value.awaitComplete
-        ? currentState.value.resultState === 'complete'
-        : currentState.value.resultState !== 'empty'
-    ) {
+    if (isAwaited(current.value)) {
       if (error.value) {
         return Promise.reject(error.value).then(onfulfilled, onrejected)
       }
@@ -1246,13 +1434,9 @@ export function useQueryImpl<
 
     return new Promise<useQuery.Result<TData, TVariables>>((resolve, reject) => {
       const stopWatch = watch(
-        currentState,
+        current,
         (newState) => {
-          if (
-            vueApolloQueryOptions.value.awaitComplete
-              ? newState.resultState === 'complete'
-              : newState.resultState !== 'empty'
-          ) {
+          if (isAwaited(newState)) {
             stopWatch()
             if (newState.error) {
               reject(newState.error)


### PR DESCRIPTION
`keepPreviousResult` retained `result` but not `resultState`, producing `resultState: 'empty'` with populated `result`, should have been impossible.

Separately, `debounce`/`throttle` produced no state transition, so `loading` stayed `false` over stale rows for the whole window.

## Changes

- Retention is correct: `result`/`resultState`/`partial` move as one unit, `loading`/`networkStatus`/`error` come from the incoming state.
- `isPreviousResult` distinguishes retained from fresh.
- `pending` covers the debounce/throttle window; `loading` now includes it.
- Retention survives `enabled` switch.

Also fixed: `awaitComplete` was never plumbed through and had no effect; `await useQuery()` hung on error; `current` is now stable.

## Notes

CI never type-checked; added a `typecheck` step and fixed the four errors it surfaced. New `useQuery.state.test.ts` covers the state transitions.