### PR TITLE
fix(useApolloClient): preserve generics in provideApolloClient(s) result type

### DIFF
--- a/packages/vue-apollo-composable/src/useApolloClient.ts
+++ b/packages/vue-apollo-composable/src/useApolloClient.ts
@@ -214,7 +214,7 @@ export function useApolloClient(clientId?: useApolloClient.ClientId): useApolloC
 export declare namespace provideApolloClient {
   export type Callback<TFnResult> = () => TFnResult
 
-  export type Result<TFnResult = any> = (fn: Callback<TFnResult>) => TFnResult
+  export type Result = <TFnResult>(fn: Callback<TFnResult>) => TFnResult
 
   export namespace DocumentationTypes {
     /** @group Providers Namespaces */
@@ -264,7 +264,7 @@ export function provideApolloClient(client: ApolloClient): provideApolloClient.R
 
 export declare namespace provideApolloClients {
   export type Callback<TFnResult> = () => TFnResult
-  export type Result<TFnResult = any> = (fn: Callback<TFnResult>) => TFnResult
+  export type Result = <TFnResult>(fn: Callback<TFnResult>) => TFnResult
 
   export namespace DocumentationTypes {
     /** @group Providers Namespaces */


### PR DESCRIPTION
## What

`provideApolloClient` and `provideApolloClients` declare their return type as `Result`, where

```ts
export type Result<TFnResult = any> = (fn: Callback<TFnResult>) => TFnResult
```

Instantiating the alias without a type argument collapses it to `(fn: () => any) => any`, so the generic on the returned implementation function never reaches callers. The documented usage pattern types as `any`:

```ts
const { current } = provideApolloClient(client)(() => useQuery(MyQuery))
// before: any — after: useQuery's actual return type
```

## Fix

Move the type parameter from the alias onto the call signature so it survives instantiation:

```ts
export type Result = <TFnResult>(fn: Callback<TFnResult>) => TFnResult
```

Applied to both `provideApolloClient.Result` and `provideApolloClients.Result`. The implementations already declare the generic, so this is a types-only change; `Result` has no parameterized (`Result<T>`) usages in the repo.

`pnpm typecheck` passes in `packages/vue-apollo-composable`, and the built `dist` JS is byte-identical before and after the change (types-only, nothing emitted changes).

## Context

Found while porting a production React + Apollo Client 4 app to Vue 3.5 against the v5 alpha, where `provideApolloClient` is the seam for using the composables outside components.
